### PR TITLE
Fix off-by-one-error in openpgp_generate_asymmetric_key_pair

### DIFF
--- a/applets/openpgp/openpgp.c
+++ b/applets/openpgp/openpgp.c
@@ -809,7 +809,7 @@ static int openpgp_generate_asymmetric_key_pair(const CAPDU *capdu, RAPDU *rapdu
       RDATA[3] = 0x86;
       RDATA[4] = KEY_SIZE_25519;
       memcpy(RDATA + 5, key + KEY_SIZE_25519, KEY_SIZE_25519);
-      LL = KEY_SIZE_25519 + 6;
+      LL = KEY_SIZE_25519 + 5;
       break;
 
     default:


### PR DESCRIPTION
Before applying this patch, when retrieving an ED25519 key from the card (with P1=0x81), a malformed TLV was returned, e.g.:

[7f, 49, 22, 86, 20, 96, e7, 2a, 33, d8, db, f0, dc, c1, d7, 1e, 63, 6a, 19, 1c, ce, bd, 9c, 46, f, b3, 66, 15, cd, 98, 48, af, 80, ab, a, a8, fc, 3c, 90, 0]

Note that the lengths in the TLV don't add up. The last byte before the status code (0x3c) is extraneous.