### PR TITLE
Fix expected expression before ';' token

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -17,9 +17,9 @@
 #define ERR_MSG(format, ...) printf("[ERR] %s(%d): " format, __func__, __LINE__, ##__VA_ARGS__)
 #define PRINT_HEX(...) print_hex(__VA_ARGS__)
 #else
-#define DBG_MSG(...)
-#define ERR_MSG(...)
-#define PRINT_HEX(...)
+#define DBG_MSG(...) do {} while(0)
+#define ERR_MSG(...) do {} while(0)
+#define PRINT_HEX(...) do {} while(0)
 #endif
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__


### PR DESCRIPTION
This happens when Werror, e.g.
```
canokey-core/applets/oath/oath.c:329:5: error: expected expression before ';' token
DBG_MSG("challenge_len=%u %hhu %hhu\n", challenge_len, record->challenge[7], challenge[7]);
```