### PR TITLE
Fix build where memcpy is a macro

### DIFF
--- a/applets/oath/oath.c
+++ b/applets/oath/oath.c
@@ -41,7 +41,7 @@ int oath_install(const uint8_t reset) {
 static int oath_select(const CAPDU *capdu, RAPDU *rapdu) {
   if (P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
 
-  memcpy(RDATA, (uint8_t[]){OATH_TAG_VERSION, 3, 0x06, 0x00, 0x00, OATH_TAG_NAME, HANDLE_LEN}, 7);
+  memcpy(RDATA, ((uint8_t[]){OATH_TAG_VERSION, 3, 0x06, 0x00, 0x00, OATH_TAG_NAME, HANDLE_LEN}), 7);
   if (read_attr(OATH_FILE, ATTR_HANDLE, RDATA + 7, HANDLE_LEN) < 0) return -1;
   LL = 7 + HANDLE_LEN;
 


### PR DESCRIPTION
I got the following compiler error with Clang 16 building for x86_64-apple-darwin:

	/tmp/nix-build-canokey-qemu-0-unstable-2023-06-06.drv-0/source/canokey-core/applets/oath/oath.c:44:50: error: too many arguments provided to function-like macro invocation
	  memcpy(RDATA, (uint8_t[]){OATH_TAG_VERSION, 3, 0x05, 0x05, 0x05, OATH_TAG_NAME, HANDLE_LEN}, 7);
	                                                 ^
	/nix/store/vw8y07yai2pjv02s1piw3r5cyhmjbddf-Libsystem-1238.60.2/include/secure/_string.h:64:9: note: macro 'memcpy' defined here
	#define memcpy(dest, src, len)                                  \
	        ^
	/tmp/nix-build-canokey-qemu-0-unstable-2023-06-06.drv-0/source/canokey-core/applets/oath/oath.c:44:3: note: parentheses are required around macro argument containing braced initializer list
	  memcpy(RDATA, (uint8_t[]){OATH_TAG_VERSION, 3, 0x05, 0x05, 0x05, OATH_TAG_NAME, HANDLE_LEN}, 7);
	  ^
	                (                                                                            )
	1 error generated.