### PR TITLE
fix: load led state cfg at startup

### DIFF
--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -70,6 +70,7 @@ int admin_install(const uint8_t reset) {
   if (reset || get_file_size(pin.path) < 0) {
     if (pin_create(&pin, "123456", 6, PIN_RETRY_COUNTER) < 0) return -1;
   }
+  stop_blinking();
   return 0;
 }
 


### PR DESCRIPTION
Currently, the led state after startup depends on device initialization code. The saved LED cfg have no effect just after powerup. I think the admin_install() function is a good place to set LED state correctly.