### PR TITLE
Enablement for dumb nRF52 dongles

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -37,7 +37,7 @@ bool device_allow_kbd_touch(void) {
 }
 
 uint8_t get_touch_result(void) {
-#ifdef TEST // emulate user interaction in test mode
+#if defined(TEST) || defined(DUMB_DONGLE) // emulate user interaction in test mode
   testmode_emulate_user_presence();
 #endif
   return touch_result;


### PR DESCRIPTION
Ref: https://github.com/canokeys/canokey-nrf52/issues/11
So instead of opening the case and pressing SW button, now touch functions could be simulated.