### PR TITLE
Refactor: binary size optimization by Opus 4.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,17 @@ endif(ENABLE_DUMB_DONGLE)
 
 add_subdirectory(canokey-crypto EXCLUDE_FROM_ALL)
 
-# tinycbor: freestanding mode (no floating-point, no tools/examples/json)
-set(WITH_FREESTANDING ON CACHE BOOL "" FORCE)
-set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
-add_subdirectory(tinycbor EXCLUDE_FROM_ALL)
+# tinycbor: build sources directly instead of add_subdirectory.
+# tinycbor 7.0's CMakeLists.txt declares project(... LANGUAGES C CXX), which
+# triggers CXX compiler detection. On ARM cross-compilation the CXX test
+# program fails to link against the scatter file (L6236E: no RESET section).
+# Avoid this by not using tinycbor's own CMake build system.
+set(TINYCBOR_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tinycbor)
+# Generate the two headers that tinycbor 7.0's cbor.h expects
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/tinycbor/tinycbor-export.h
+    "#ifndef CBOR_API\n#define CBOR_API\n#endif\n")
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/tinycbor/tinycbor-version.h
+    "#define TINYCBOR_VERSION_MAJOR 7\n#define TINYCBOR_VERSION_MINOR 0\n#define TINYCBOR_VERSION_PATCH 0\n")
 
 if(DEFINED PRODUCT_NAME)
     add_definitions(-DUSBD_PRODUCT_STRING="${PRODUCT_NAME}")
@@ -50,6 +57,8 @@ file(
     interfaces/*.c
     littlefs/lfs.c
     littlefs/lfs_util.c
+    tinycbor/src/cborencoder.c
+    tinycbor/src/cborparser.c
 )
 add_library(canokey-core ${SRC})
 
@@ -70,6 +79,8 @@ target_include_directories(
     PUBLIC
         include
         littlefs
+        tinycbor/src
+        ${CMAKE_CURRENT_BINARY_DIR}/tinycbor
         interfaces/USB/device
         interfaces/USB/core/inc
         interfaces/USB/class/ccid
@@ -77,7 +88,8 @@ target_include_directories(
         interfaces/USB/class/kbdhid
         interfaces/USB/class/webusb
 )
-target_link_libraries(canokey-core canokey-crypto tinycbor)
+target_compile_definitions(canokey-core PRIVATE CBOR_NO_FLOATING_POINT CBOR_STATIC_DEFINE)
+target_link_libraries(canokey-core canokey-crypto)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -127,16 +127,16 @@ int ctap_write_sm2_config(const CAPDU *capdu, RAPDU *rapdu) {
   return ret;
 }
 
-static int build_ecdsa_cose_key(uint8_t *data, int algo, int curve) {
+static int build_cose_key(uint8_t *data, int kty, int algo, int curve, bool has_y) {
   uint8_t buf[80];
   CborEncoder encoder, map_encoder;
 
   cbor_encoder_init(&encoder, buf, sizeof(buf), 0);
-  CborError ret = cbor_encoder_create_map(&encoder, &map_encoder, 5);
+  CborError ret = cbor_encoder_create_map(&encoder, &map_encoder, has_y ? 5 : 4);
   CHECK_CBOR_RET(ret);
   ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_KTY);
   CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_KTY_EC2);
+  ret = cbor_encode_int(&map_encoder, kty);
   CHECK_CBOR_RET(ret);
   ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_ALG);
   CHECK_CBOR_RET(ret);
@@ -150,41 +150,12 @@ static int build_ecdsa_cose_key(uint8_t *data, int algo, int curve) {
   CHECK_CBOR_RET(ret);
   ret = cbor_encode_byte_string(&map_encoder, data, 32);
   CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_Y);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_byte_string(&map_encoder, data + 32, 32);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_close_container(&encoder, &map_encoder);
-  CHECK_CBOR_RET(ret);
-
-  const int len = cbor_encoder_get_buffer_size(&encoder, buf);
-  memcpy(data, buf, len);
-  return len;
-}
-
-static int build_ed25519_cose_key(uint8_t *data) {
-  uint8_t buf[50];
-  CborEncoder encoder, map_encoder;
-
-  cbor_encoder_init(&encoder, buf, sizeof(buf), 0);
-  CborError ret = cbor_encoder_create_map(&encoder, &map_encoder, 4);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_KTY);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_KTY_OKP);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_ALG);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_ALG_EDDSA);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_CRV);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_CRV_ED25519);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_X);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_byte_string(&map_encoder, data, 32);
-  CHECK_CBOR_RET(ret);
+  if (has_y) {
+    ret = cbor_encode_int(&map_encoder, COSE_KEY_LABEL_Y);
+    CHECK_CBOR_RET(ret);
+    ret = cbor_encode_byte_string(&map_encoder, data + 32, 32);
+    CHECK_CBOR_RET(ret);
+  }
   ret = cbor_encoder_close_container(&encoder, &map_encoder);
   CHECK_CBOR_RET(ret);
 
@@ -288,11 +259,11 @@ uint8_t ctap_make_auth_data(uint8_t *rp_id_hash, uint8_t *buf, uint8_t flags, co
     }
     int cose_key_size;
     if (alg_type == COSE_ALG_ES256) {
-      cose_key_size = build_ecdsa_cose_key(ad->at.public_key, COSE_ALG_ES256, COSE_KEY_CRV_P256);
+      cose_key_size = build_cose_key(ad->at.public_key, COSE_KEY_KTY_EC2, COSE_ALG_ES256, COSE_KEY_CRV_P256, true);
     } else if (alg_type == COSE_ALG_EDDSA) {
-      cose_key_size = build_ed25519_cose_key(ad->at.public_key);
+      cose_key_size = build_cose_key(ad->at.public_key, COSE_KEY_KTY_OKP, COSE_ALG_EDDSA, COSE_KEY_CRV_ED25519, false);
     } else if (alg_type == ctap_sm2_attr.algo_id) {
-      cose_key_size = build_ecdsa_cose_key(ad->at.public_key, ctap_sm2_attr.algo_id, ctap_sm2_attr.curve_id);
+      cose_key_size = build_cose_key(ad->at.public_key, COSE_KEY_KTY_EC2, ctap_sm2_attr.algo_id, ctap_sm2_attr.curve_id, true);
     } else {
       DBG_MSG("Unknown algorithm type\n");
       return CTAP2_ERR_UNHANDLED_REQUEST;
@@ -1365,49 +1336,23 @@ static uint8_t ctap_get_info(CborEncoder *encoder) {
   CHECK_CBOR_RET(ret);
   ret = cbor_encoder_create_array(&map, &array, ctap_sm2_attr.enabled ? 3 : 2);
   CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_map(&array, &sub_map, 2);
-  CHECK_CBOR_RET(ret);
   {
-    ret = cbor_encode_text_stringz(&sub_map, "alg");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&sub_map, COSE_ALG_ES256);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "type");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "public-key");
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&array, &sub_map);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_map(&array, &sub_map, 2);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_text_stringz(&sub_map, "alg");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&sub_map, COSE_ALG_EDDSA);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "type");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "public-key");
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&array, &sub_map);
-  CHECK_CBOR_RET(ret);
-  if (ctap_sm2_attr.enabled) {
-    ret = cbor_encoder_create_map(&array, &sub_map, 2);
-    CHECK_CBOR_RET(ret);
-    {
+    const int algs[] = {COSE_ALG_ES256, COSE_ALG_EDDSA, ctap_sm2_attr.algo_id};
+    int n_algs = ctap_sm2_attr.enabled ? 3 : 2;
+    for (int i = 0; i < n_algs; ++i) {
+      ret = cbor_encoder_create_map(&array, &sub_map, 2);
+      CHECK_CBOR_RET(ret);
       ret = cbor_encode_text_stringz(&sub_map, "alg");
       CHECK_CBOR_RET(ret);
-      ret = cbor_encode_int(&sub_map, ctap_sm2_attr.algo_id);
+      ret = cbor_encode_int(&sub_map, algs[i]);
       CHECK_CBOR_RET(ret);
       ret = cbor_encode_text_stringz(&sub_map, "type");
       CHECK_CBOR_RET(ret);
       ret = cbor_encode_text_stringz(&sub_map, "public-key");
       CHECK_CBOR_RET(ret);
+      ret = cbor_encoder_close_container(&array, &sub_map);
+      CHECK_CBOR_RET(ret);
     }
-    ret = cbor_encoder_close_container(&array, &sub_map);
-    CHECK_CBOR_RET(ret);
   }
   ret = cbor_encoder_close_container(&map, &array);
   CHECK_CBOR_RET(ret);
@@ -1470,7 +1415,7 @@ static uint8_t ctap_client_pin(CborEncoder *encoder, const uint8_t *params, size
     CHECK_CBOR_RET(ret);
     ptr = key_map.data.ptr - 1;
     cp_get_public_key(ptr);
-    cose_key_size = build_ecdsa_cose_key(ptr, COSE_ALG_ECDH_ES_HKDF_256, COSE_KEY_CRV_P256);
+    cose_key_size = build_cose_key(ptr, COSE_KEY_KTY_EC2, COSE_ALG_ECDH_ES_HKDF_256, COSE_KEY_CRV_P256, true);
     key_map.data.ptr = ptr + cose_key_size;
     ret = cbor_encoder_close_container(&map, &key_map);
     CHECK_CBOR_RET(ret);
@@ -1721,29 +1666,7 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
     DBG_MSG("%d RPs found\n", counter);
     size = read_file(DC_META_FILE, &meta, idx * (int)sizeof(CTAP_rp_meta), sizeof(CTAP_rp_meta));
     if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-    ret = cbor_encoder_create_map(encoder, &map, 3);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&map, CM_RESP_RP);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_create_map(&map, &sub_map, 1);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "id");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_string(&sub_map, (const char *)meta.rp_id, meta.rp_id_len);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_close_container(&map, &sub_map);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&map, CM_RESP_RP_ID_HASH);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_byte_string(&map, meta.rp_id_hash, SHA256_DIGEST_LENGTH);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&map, CM_RESP_TOTAL_RPS);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&map, counter);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_close_container(encoder, &map);
-    CHECK_CBOR_RET(ret);
-    break;
+    goto encode_rp_begin;
 
   case CM_CMD_ENUMERATE_RPS_GET_NEXT_RP:
     if (last_cmd != CTAP_CREDENTIAL_MANAGEMENT ||
@@ -1761,7 +1684,9 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
         break;
       }
     }
-    ret = cbor_encoder_create_map(encoder, &map, 2);
+    counter = -1; // signal: no TOTAL_RPS field
+  encode_rp_begin:
+    ret = cbor_encoder_create_map(encoder, &map, counter >= 0 ? 3 : 2);
     CHECK_CBOR_RET(ret);
     ret = cbor_encode_int(&map, CM_RESP_RP);
     CHECK_CBOR_RET(ret);
@@ -1777,6 +1702,12 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
     CHECK_CBOR_RET(ret);
     ret = cbor_encode_byte_string(&map, meta.rp_id_hash, SHA256_DIGEST_LENGTH);
     CHECK_CBOR_RET(ret);
+    if (counter >= 0) {
+      ret = cbor_encode_int(&map, CM_RESP_TOTAL_RPS);
+      CHECK_CBOR_RET(ret);
+      ret = cbor_encode_int(&map, counter);
+      CHECK_CBOR_RET(ret);
+    }
     ret = cbor_encoder_close_container(encoder, &map);
     CHECK_CBOR_RET(ret);
     break;
@@ -1858,10 +1789,10 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
     uint8_t *ptr = sub_map.data.ptr - 1;
     memcpy(ptr, key.pub, PUBLIC_KEY_LENGTH[key_type]);
     if (dc.credential_id.alg_type == COSE_ALG_ES256) {
-      int cose_key_size = build_ecdsa_cose_key(ptr, COSE_ALG_ES256, COSE_KEY_CRV_P256);
+      int cose_key_size = build_cose_key(ptr, COSE_KEY_KTY_EC2, COSE_ALG_ES256, COSE_KEY_CRV_P256, true);
       sub_map.data.ptr = ptr + cose_key_size;
     } else if (dc.credential_id.alg_type == COSE_ALG_EDDSA) {
-      int cose_key_size = build_ed25519_cose_key(ptr);
+      int cose_key_size = build_cose_key(ptr, COSE_KEY_KTY_OKP, COSE_ALG_EDDSA, COSE_KEY_CRV_ED25519, false);
       sub_map.data.ptr = ptr + cose_key_size;
     }
     ret = cbor_encoder_close_container(&map, &sub_map);

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -263,7 +263,8 @@ uint8_t ctap_make_auth_data(uint8_t *rp_id_hash, uint8_t *buf, uint8_t flags, co
     } else if (alg_type == COSE_ALG_EDDSA) {
       cose_key_size = build_cose_key(ad->at.public_key, COSE_KEY_KTY_OKP, COSE_ALG_EDDSA, COSE_KEY_CRV_ED25519, false);
     } else if (alg_type == ctap_sm2_attr.algo_id) {
-      cose_key_size = build_cose_key(ad->at.public_key, COSE_KEY_KTY_EC2, ctap_sm2_attr.algo_id, ctap_sm2_attr.curve_id, true);
+      cose_key_size =
+          build_cose_key(ad->at.public_key, COSE_KEY_KTY_EC2, ctap_sm2_attr.algo_id, ctap_sm2_attr.curve_id, true);
     } else {
       DBG_MSG("Unknown algorithm type\n");
       return CTAP2_ERR_UNHANDLED_REQUEST;
@@ -1675,14 +1676,19 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
       return CTAP2_ERR_NOT_ALLOWED;
     }
     last_cm_cmd = cm.sub_command;
-    for (int i = idx + 1; i < n_rp; ++i) {
-      size = read_file(DC_META_FILE, &meta, i * (int)sizeof(CTAP_rp_meta), sizeof(CTAP_rp_meta));
-      if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-      if (meta.slots > 0) {
-        DBG_MSG("Fetch RP at %d\n", i);
-        idx = i;
-        break;
+    {
+      bool found = false;
+      for (int i = idx + 1; i < n_rp; ++i) {
+        size = read_file(DC_META_FILE, &meta, i * (int)sizeof(CTAP_rp_meta), sizeof(CTAP_rp_meta));
+        if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
+        if (meta.slots > 0) {
+          DBG_MSG("Fetch RP at %d\n", i);
+          idx = i;
+          found = true;
+          break;
+        }
       }
+      if (!found) return CTAP2_ERR_NOT_ALLOWED;
     }
     counter = -1; // signal: no TOTAL_RPS field
   encode_rp_begin:

--- a/applets/oath/oath.c
+++ b/applets/oath/oath.c
@@ -13,6 +13,22 @@
 #define OATH_FILE "oath"
 #define MAX_RECORDS 100
 
+/**
+ * Find a record by name. On success, populates *record and *file_offset, returns slot index.
+ * Returns -1 if not found, -2 on I/O error.
+ */
+static int oath_find_record(const uint8_t *name, uint8_t name_len, OATH_RECORD *record, size_t *file_offset) {
+  const int size = get_file_size(OATH_FILE);
+  if (size < 0) return -2;
+  const size_t n_records = size / sizeof(OATH_RECORD);
+  for (size_t i = 0; i < n_records; ++i) {
+    *file_offset = i * sizeof(OATH_RECORD);
+    if (read_file(OATH_FILE, record, *file_offset, sizeof(OATH_RECORD)) < 0) return -2;
+    if (record->name_len == name_len && memcmp(record->name, name, name_len) == 0) return (int)i;
+  }
+  return -1;
+}
+
 static enum {
   REMAINING_NONE,
   REMAINING_CALC_FULL,
@@ -158,19 +174,14 @@ static int oath_delete(const CAPDU *capdu, RAPDU *rapdu) {
   if (LC < offset) EXCEPT(SW_WRONG_LENGTH);
 
   // find and delete the record
-  const int size = get_file_size(OATH_FILE);
-  if (size < 0) return -1;
-  const size_t n_records = size / sizeof(OATH_RECORD);
   OATH_RECORD record;
-  for (size_t i = 0; i != n_records; ++i) {
-    if (read_file(OATH_FILE, &record, i * sizeof(OATH_RECORD), sizeof(OATH_RECORD)) < 0) return -1;
-    if (record.name_len == name_len && memcmp(record.name, name_ptr, name_len) == 0) {
-      if (pass_delete_oath(i * sizeof(OATH_RECORD)) < 0) return -1;
-      record.name_len = 0;
-      return write_file(OATH_FILE, &record, i * sizeof(OATH_RECORD), sizeof(OATH_RECORD), 0);
-    }
-  }
-  EXCEPT(SW_DATA_INVALID);
+  size_t file_offset;
+  int idx = oath_find_record(name_ptr, name_len, &record, &file_offset);
+  if (idx == -2) return -1;
+  if (idx == -1) EXCEPT(SW_DATA_INVALID);
+  if (pass_delete_oath(file_offset) < 0) return -1;
+  record.name_len = 0;
+  return write_file(OATH_FILE, &record, file_offset, sizeof(OATH_RECORD), 0);
 }
 
 static int oath_rename(const CAPDU *capdu, RAPDU *rapdu) {
@@ -424,18 +435,11 @@ static int oath_set_default(const CAPDU *capdu, RAPDU *rapdu) {
   if (offset > LC) EXCEPT(SW_WRONG_LENGTH);
 
   // find the record
-  const int size = get_file_size(OATH_FILE);
-  if (size < 0) return -1;
-  const uint32_t n_records = size / sizeof(OATH_RECORD);
-  uint32_t i;
-  uint32_t file_offset = 0;
   OATH_RECORD record;
-  for (i = 0; i != n_records; ++i) {
-    file_offset = i * sizeof(OATH_RECORD);
-    if (read_file(OATH_FILE, &record, file_offset, sizeof(OATH_RECORD)) < 0) return -1;
-    if (record.name_len == name_len && memcmp(record.name, name_ptr, name_len) == 0) break;
-  }
-  if (i == n_records) EXCEPT(SW_DATA_INVALID);
+  size_t file_offset;
+  int idx = oath_find_record(name_ptr, name_len, &record, &file_offset);
+  if (idx == -2) return -1;
+  if (idx == -1) EXCEPT(SW_DATA_INVALID);
   if ((record.key[0] & OATH_TYPE_MASK) == OATH_TYPE_TOTP) EXCEPT(SW_CONDITIONS_NOT_SATISFIED);
 
   return pass_update_oath(P1 - 1, file_offset, record.name_len, record.name, P2);
@@ -453,18 +457,11 @@ static int oath_calculate(const CAPDU *capdu, RAPDU *rapdu) {
   if (LC < offset) EXCEPT(SW_WRONG_LENGTH);
 
   // find the record
-  const int size = get_file_size(OATH_FILE);
-  if (size < 0) return -1;
-  const size_t n_records = size / sizeof(OATH_RECORD);
-  size_t i;
-  size_t file_offset = 0;
   OATH_RECORD record;
-  for (i = 0; i != n_records; ++i) {
-    file_offset = i * sizeof(OATH_RECORD);
-    if (read_file(OATH_FILE, &record, file_offset, sizeof(OATH_RECORD)) < 0) return -1;
-    if (record.name_len == name_len && memcmp(record.name, DATA + 2, name_len) == 0) break;
-  }
-  if (i == n_records) EXCEPT(SW_DATA_INVALID);
+  size_t file_offset;
+  int idx = oath_find_record(DATA + 2, name_len, &record, &file_offset);
+  if (idx == -2) return -1;
+  if (idx == -1) EXCEPT(SW_DATA_INVALID);
 
   if (record.prop & OATH_PROP_TOUCH) {
     if (!is_nfc()) {

--- a/applets/openpgp/openpgp.c
+++ b/applets/openpgp/openpgp.c
@@ -336,6 +336,27 @@ static int openpgp_select(const CAPDU *capdu, RAPDU *rapdu) {
   return 0;
 }
 
+/**
+ * Fill PW_STATUS bytes into buf[0..PW_STATUS_LENGTH-1].
+ * Returns PW_STATUS_LENGTH on success, -1 on I/O error.
+ */
+static int fill_pw_status(uint8_t *buf) {
+  if (read_attr(DATA_PATH, TAG_PW_STATUS, buf, 1) < 0) return -1;
+  buf[1] = MAX_PIN_LENGTH;
+  buf[2] = MAX_PIN_LENGTH;
+  buf[3] = MAX_PIN_LENGTH;
+  int retries = pin_get_retries(&pw1);
+  if (retries < 0) return -1;
+  buf[4] = retries;
+  retries = pin_get_retries(&rc);
+  if (retries < 0) return -1;
+  buf[5] = retries;
+  retries = pin_get_retries(&pw3);
+  if (retries < 0) return -1;
+  buf[6] = retries;
+  return PW_STATUS_LENGTH;
+}
+
 static int openpgp_get_data(const CAPDU *capdu, RAPDU *rapdu) {
   if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
 
@@ -447,19 +468,8 @@ static int openpgp_get_data(const CAPDU *capdu, RAPDU *rapdu) {
 
     RDATA[off++] = TAG_PW_STATUS;
     RDATA[off++] = PW_STATUS_LENGTH;
-    if (read_attr(DATA_PATH, TAG_PW_STATUS, RDATA + off++, 1) < 0) return -1;
-    RDATA[off++] = MAX_PIN_LENGTH;
-    RDATA[off++] = MAX_PIN_LENGTH;
-    RDATA[off++] = MAX_PIN_LENGTH;
-    retries = pin_get_retries(&pw1);
-    if (retries < 0) return -1;
-    RDATA[off++] = retries;
-    retries = pin_get_retries(&rc);
-    if (retries < 0) return -1;
-    RDATA[off++] = retries;
-    retries = pin_get_retries(&pw3);
-    if (retries < 0) return -1;
-    RDATA[off++] = retries;
+    if (fill_pw_status(RDATA + off) < 0) return -1;
+    off += PW_STATUS_LENGTH;
 
     RDATA[off++] = TAG_KEY_FINGERPRINTS;
     RDATA[off++] = KEY_FINGERPRINT_LENGTH * NUM_KEYS;
@@ -539,19 +549,7 @@ static int openpgp_get_data(const CAPDU *capdu, RAPDU *rapdu) {
     break;
 
   case TAG_PW_STATUS:
-    if (read_attr(DATA_PATH, TAG_PW_STATUS, RDATA, 1) < 0) return -1;
-    RDATA[1] = MAX_PIN_LENGTH;
-    RDATA[2] = MAX_PIN_LENGTH;
-    RDATA[3] = MAX_PIN_LENGTH;
-    retries = pin_get_retries(&pw1);
-    if (retries < 0) return -1;
-    RDATA[4] = retries;
-    retries = pin_get_retries(&rc);
-    if (retries < 0) return -1;
-    RDATA[5] = retries;
-    retries = pin_get_retries(&pw3);
-    if (retries < 0) return -1;
-    RDATA[6] = retries;
+    if (fill_pw_status(RDATA) < 0) return -1;
     LL = PW_STATUS_LENGTH;
     break;
 

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -69,10 +69,10 @@
 #define IDX_RESPONSE  (TAG_RESPONSE  - 0x80)
 
 /**
- * Build a 0x7C TLV wrapper around data already placed in RDATA.
- * For short lengths (< 128): header at RDATA[0..3], data starts at RDATA+4.
- * For extended lengths (>= 128): header at RDATA[0..7], data starts at RDATA+8.
- * Returns the total LL value and sets *data_offset to where data should be written.
+ * Build a 0x7C TLV wrapper in rdata.
+ * For short lengths (< 128): header at rdata[0..3], data starts at rdata+4.
+ * For extended lengths (>= 128): header at rdata[0..7], data starts at rdata+8.
+ * Returns the total response length (header + data_len).
  */
 static uint16_t piv_7c_wrap(uint8_t *rdata, uint8_t inner_tag, uint16_t data_len) {
   if (data_len < 128) {
@@ -794,7 +794,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
       EXCEPT(SW_WRONG_LENGTH);
     }
 
-        LL = piv_7c_wrap(RDATA, TAG_RESPONSE, TDEA_BLOCK_SIZE);
+    LL = piv_7c_wrap(RDATA, TAG_RESPONSE, TDEA_BLOCK_SIZE);
 
     if (ck_read_key(key_path, &key) < 0) return -1;
     DBG_KEY_META(&key.meta);
@@ -837,7 +837,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
       return -1;
     }
 
-        LL = piv_7c_wrap(RDATA, TAG_RESPONSE, PRIVATE_KEY_LENGTH[key.meta.type]);
+    LL = piv_7c_wrap(RDATA, TAG_RESPONSE, PRIVATE_KEY_LENGTH[key.meta.type]);
 
     memzero(&key, sizeof(key));
   }

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -67,6 +67,32 @@
 #define IDX_WITNESS   (TAG_WITNESS   - 0x80)
 #define IDX_CHALLENGE (TAG_CHALLENGE - 0x80)
 #define IDX_RESPONSE  (TAG_RESPONSE  - 0x80)
+
+/**
+ * Build a 0x7C TLV wrapper around data already placed in RDATA.
+ * For short lengths (< 128): header at RDATA[0..3], data starts at RDATA+4.
+ * For extended lengths (>= 128): header at RDATA[0..7], data starts at RDATA+8.
+ * Returns the total LL value and sets *data_offset to where data should be written.
+ */
+static uint16_t piv_7c_wrap(uint8_t *rdata, uint8_t inner_tag, uint16_t data_len) {
+  if (data_len < 128) {
+    rdata[0] = 0x7C;
+    rdata[1] = (uint8_t)(data_len + 2);
+    rdata[2] = inner_tag;
+    rdata[3] = (uint8_t)data_len;
+    return data_len + 4;
+  } else {
+    rdata[0] = 0x7C;
+    rdata[1] = 0x82;
+    rdata[2] = HI(data_len + 4);
+    rdata[3] = LO(data_len + 4);
+    rdata[4] = inner_tag;
+    rdata[5] = 0x82;
+    rdata[6] = HI(data_len);
+    rdata[7] = LO(data_len);
+    return data_len + 8;
+  }
+}
 #define IDX_EXP       (TAG_EXP       - 0x80)
 // clang-format on
 
@@ -648,15 +674,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
         memzero(&key, sizeof(key));
         return -1;
       }
-      RDATA[0] = 0x7C;
-      RDATA[1] = 0x82;
-      RDATA[2] = HI(SIGNATURE_LENGTH[key.meta.type] + 4);
-      RDATA[3] = LO(SIGNATURE_LENGTH[key.meta.type] + 4);
-      RDATA[4] = TAG_RESPONSE;
-      RDATA[5] = 0x82;
-      RDATA[6] = HI(SIGNATURE_LENGTH[key.meta.type]);
-      RDATA[7] = LO(SIGNATURE_LENGTH[key.meta.type]);
-      LL = SIGNATURE_LENGTH[key.meta.type] + 8;
+      LL = piv_7c_wrap(RDATA, TAG_RESPONSE, SIGNATURE_LENGTH[key.meta.type]);
 
       memzero(&key, sizeof(key));
     } else if (IS_ECC(key.meta.type)) {
@@ -678,11 +696,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
         sig_len = (int)ecdsa_sig2ansi(PRIVATE_KEY_LENGTH[key.meta.type], RDATA + 4, RDATA + 4);
       }
 
-      RDATA[0] = 0x7C;
-      RDATA[1] = sig_len + 2;
-      RDATA[2] = TAG_RESPONSE;
-      RDATA[3] = sig_len;
-      LL = sig_len + 4;
+      LL = piv_7c_wrap(RDATA, TAG_RESPONSE, sig_len);
 
       memzero(&key, sizeof(key));
     } else
@@ -702,12 +716,8 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
 
     if (P2 != 0x9B) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 
-    RDATA[0] = 0x7C;
-    RDATA[1] = TDEA_BLOCK_SIZE + 2;
-    RDATA[2] = TAG_CHALLENGE;
-    RDATA[3] = TDEA_BLOCK_SIZE;
+    LL = piv_7c_wrap(RDATA, TAG_CHALLENGE, TDEA_BLOCK_SIZE);
     random_buffer(RDATA + 4, TDEA_BLOCK_SIZE);
-    LL = TDEA_BLOCK_SIZE + 4;
 
     auth_ctx[OFFSET_AUTH_STATE] = AUTH_STATE_EXTERNAL;
 
@@ -753,11 +763,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
     auth_ctx[OFFSET_AUTH_STATE] = AUTH_STATE_MUTUAL;
     random_buffer(auth_ctx + OFFSET_AUTH_CHALLENGE, TDEA_BLOCK_SIZE);
 
-    RDATA[0] = 0x7C;
-    RDATA[1] = TDEA_BLOCK_SIZE + 2;
-    RDATA[2] = TAG_WITNESS;
-    RDATA[3] = TDEA_BLOCK_SIZE;
-    LL = TDEA_BLOCK_SIZE + 4;
+    LL = piv_7c_wrap(RDATA, TAG_WITNESS, TDEA_BLOCK_SIZE);
 
     if (ck_read_key(key_path, &key) < 0) return -1;
     DBG_KEY_META(&key.meta);
@@ -788,11 +794,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
       EXCEPT(SW_WRONG_LENGTH);
     }
 
-    RDATA[0] = 0x7C;
-    RDATA[1] = TDEA_BLOCK_SIZE + 2;
-    RDATA[2] = TAG_RESPONSE;
-    RDATA[3] = TDEA_BLOCK_SIZE;
-    LL = TDEA_BLOCK_SIZE + 4;
+        LL = piv_7c_wrap(RDATA, TAG_RESPONSE, TDEA_BLOCK_SIZE);
 
     if (ck_read_key(key_path, &key) < 0) return -1;
     DBG_KEY_META(&key.meta);
@@ -835,11 +837,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
       return -1;
     }
 
-    RDATA[0] = 0x7C;
-    RDATA[1] = PRIVATE_KEY_LENGTH[key.meta.type] + 2;
-    RDATA[2] = TAG_RESPONSE;
-    RDATA[3] = PRIVATE_KEY_LENGTH[key.meta.type];
-    LL = PRIVATE_KEY_LENGTH[key.meta.type] + 4;
+        LL = piv_7c_wrap(RDATA, TAG_RESPONSE, PRIVATE_KEY_LENGTH[key.meta.type]);
 
     memzero(&key, sizeof(key));
   }

--- a/src/key.c
+++ b/src/key.c
@@ -308,7 +308,8 @@ int ck_parse_openpgp(ck_key_t *key, const uint8_t *buf, size_t buf_len) {
     if ((size_t)(p + 2 - buf) >= buf_len) return KEY_ERR_LENGTH;
     if (*p++ != 0x5F || *p++ != 0x48) return KEY_ERR_DATA;
     size_t total_data = 0;
-    for (int i = 0; i < 6; ++i) total_data += comp_len[i];
+    for (int i = 0; i < 6; ++i)
+      total_data += comp_len[i];
     len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
     if (fail) return KEY_ERR_LENGTH;
     if (len != total_data) return KEY_ERR_DATA;

--- a/src/key.c
+++ b/src/key.c
@@ -288,75 +288,41 @@ int ck_parse_openpgp(ck_key_t *key, const uint8_t *buf, size_t buf_len) {
   case RSA2048:
   case RSA3072:
   case RSA4096: {
-    // 0x91: e
-    if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
-    if (*p++ != 0x91) return KEY_ERR_DATA;
-    len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
-    if (fail) return KEY_ERR_LENGTH;
-    if (len != E_LENGTH) return KEY_ERR_DATA;
-    p += length_size;
+    // Parse 6 RSA CRT component tags: 0x91(e), 0x92(p), 0x93(q), 0x94(qinv), 0x95(dp), 0x96(dq)
+    static const uint8_t rsa_tags[] = {0x91, 0x92, 0x93, 0x94, 0x95, 0x96};
+    const size_t pri_len = PRIVATE_KEY_LENGTH[key->meta.type];
+    // expected lengths: e=E_LENGTH, p=pri_len, q=pri_len, qinv/dp/dq <= pri_len
+    const size_t expected_exact[] = {E_LENGTH, pri_len, pri_len, 0, 0, 0};
+    size_t comp_len[6];
+    for (int i = 0; i < 6; ++i) {
+      if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
+      if (*p++ != rsa_tags[i]) return KEY_ERR_DATA;
+      comp_len[i] = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
+      if (fail) return KEY_ERR_LENGTH;
+      if (expected_exact[i] > 0 ? comp_len[i] != expected_exact[i] : comp_len[i] > pri_len) return KEY_ERR_DATA;
+      p += length_size;
+    }
 
-    // 0x92: p
-    if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
-    if (*p++ != 0x92) return KEY_ERR_DATA;
-    len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
-    if (fail) return KEY_ERR_LENGTH;
-    if (len != PRIVATE_KEY_LENGTH[key->meta.type]) return KEY_ERR_DATA;
-    p += length_size;
-
-    // 0x93: q
-    if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
-    if (*p++ != 0x93) return KEY_ERR_DATA;
-    len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
-    if (fail) return KEY_ERR_LENGTH;
-    if (len != PRIVATE_KEY_LENGTH[key->meta.type]) return KEY_ERR_DATA;
-    p += length_size;
-
-    // 0x94: qinv, may be less than p/q's length
-    if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
-    if (*p++ != 0x94) return KEY_ERR_DATA;
-    const size_t qinv_len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
-    if (fail) return KEY_ERR_LENGTH;
-    if (qinv_len > PRIVATE_KEY_LENGTH[key->meta.type]) return KEY_ERR_DATA;
-    p += length_size;
-
-    // 0x94: dp, may be less than p/q's length
-    if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
-    if (*p++ != 0x95) return KEY_ERR_DATA;
-    const size_t dp_len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
-    if (fail) return KEY_ERR_LENGTH;
-    if (dp_len > PRIVATE_KEY_LENGTH[key->meta.type]) return KEY_ERR_DATA;
-    p += length_size;
-
-    // 0x94: dq, may be less than p/q's length
-    if ((size_t)(p + 1 - buf) >= buf_len) return KEY_ERR_LENGTH;
-    if (*p++ != 0x96) return KEY_ERR_DATA;
-    const size_t dq_len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
-    if (fail) return KEY_ERR_LENGTH;
-    if (dq_len > PRIVATE_KEY_LENGTH[key->meta.type]) return KEY_ERR_DATA;
-
-    // Concatenation of key data
+    // Concatenation of key data (tag 5F48)
     p = data_tag;
     if ((size_t)(p + 2 - buf) >= buf_len) return KEY_ERR_LENGTH;
     if (*p++ != 0x5F || *p++ != 0x48) return KEY_ERR_DATA;
+    size_t total_data = 0;
+    for (int i = 0; i < 6; ++i) total_data += comp_len[i];
     len = tlv_get_length_safe(p, buf_len - (p - buf), &fail, &length_size);
     if (fail) return KEY_ERR_LENGTH;
-    if (len != PRIVATE_KEY_LENGTH[key->meta.type] * 2 + qinv_len + dp_len + dq_len + E_LENGTH) return KEY_ERR_DATA;
+    if (len != total_data) return KEY_ERR_DATA;
     p += length_size;
 
     if ((size_t)(p + len - buf) > buf_len) return KEY_ERR_LENGTH;
-    key->rsa.nbits = PRIVATE_KEY_LENGTH[key->meta.type] * 16;
-    memcpy(key->rsa.e, p, E_LENGTH);
-    p += E_LENGTH;
-    memcpy(key->rsa.p, p, PRIVATE_KEY_LENGTH[key->meta.type]);
-    p += PRIVATE_KEY_LENGTH[key->meta.type];
-    memcpy(key->rsa.q, p, PRIVATE_KEY_LENGTH[key->meta.type]);
-    p += PRIVATE_KEY_LENGTH[key->meta.type];
-    memcpy(key->rsa.qinv + PRIVATE_KEY_LENGTH[key->meta.type] - qinv_len, p, qinv_len);
-    p += qinv_len;
-    memcpy(key->rsa.dp + PRIVATE_KEY_LENGTH[key->meta.type] - dp_len, p, dp_len);
-    p += dp_len;
-    memcpy(key->rsa.dq + PRIVATE_KEY_LENGTH[key->meta.type] - dq_len, p, dq_len);
+    key->rsa.nbits = pri_len * 16;
+    // Copy components: e, p, q are exact-length; qinv, dp, dq are right-aligned
+    uint8_t *dests[] = {key->rsa.e, key->rsa.p, key->rsa.q, key->rsa.qinv, key->rsa.dp, key->rsa.dq};
+    for (int i = 0; i < 6; ++i) {
+      size_t offset = (i >= 3) ? pri_len - comp_len[i] : 0;
+      memcpy(dests[i] + offset, p, comp_len[i]);
+      p += comp_len[i];
+    }
     if (be32toh(*(uint32_t *)key->rsa.p) < CEIL_DIV_SQRT2 || be32toh(*(uint32_t *)key->rsa.q) < CEIL_DIV_SQRT2) {
       memzero(key, sizeof(ck_key_t));
       return KEY_ERR_DATA;


### PR DESCRIPTION
Disclaimer: all work done by Claude Opus 4.6.

This pull request refactors and simplifies code across several applets, focusing on code reuse, maintainability, and clarity. The main changes include consolidating duplicate logic into helper functions, improving the structure of COSE key encoding in the CTAP applet, and introducing utility functions for TLV wrapping and PIN status handling. These changes reduce code duplication, make future maintenance easier, and clarify intent in several critical flows.

**CTAP applet improvements:**

* Consolidated ECDSA and Ed25519 COSE key encoding into a single `build_cose_key` function, removing the now-unnecessary `build_ecdsa_cose_key` and `build_ed25519_cose_key` functions and updating all call sites to use the new function. This simplifies key encoding logic and reduces code duplication. [[1]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L130-R139) [[2]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761R153-L187) [[3]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L291-R266) [[4]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1473-R1418) [[5]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1861-R1795)
* Refactored the supported algorithms encoding in `ctap_get_info` to use a loop, making the code more maintainable and less error-prone when adding or removing algorithms.
* Improved credential management response encoding by consolidating repeated code into a single block with a shared label, and handling the optional `TOTAL_RPS` field more cleanly. [[1]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1724-R1669) [[2]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1764-R1689) [[3]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761R1705-R1710)

**OATH applet improvements:**

* Introduced the `oath_find_record` helper function to centralize record lookup logic, replacing repeated code in multiple functions (`oath_delete`, `oath_set_default`, `oath_calculate`) and improving error handling for not-found and I/O error cases. [[1]](diffhunk://#diff-c91456844129c3881a0e91545538d1f4d7b67346581611da8104975e473afc94R16-R31) [[2]](diffhunk://#diff-c91456844129c3881a0e91545538d1f4d7b67346581611da8104975e473afc94L161-R184) [[3]](diffhunk://#diff-c91456844129c3881a0e91545538d1f4d7b67346581611da8104975e473afc94L427-R442) [[4]](diffhunk://#diff-c91456844129c3881a0e91545538d1f4d7b67346581611da8104975e473afc94L456-R464)

**OpenPGP applet improvements:**

* Added the `fill_pw_status` utility to encapsulate PIN status byte filling, replacing repeated inline logic in `openpgp_get_data` and improving clarity and maintainability. [[1]](diffhunk://#diff-be09807abb544c94b592d8832aa39bfd5e144f45edc5a9c809a5246bed69688cR339-R359) [[2]](diffhunk://#diff-be09807abb544c94b592d8832aa39bfd5e144f45edc5a9c809a5246bed69688cL450-R472) [[3]](diffhunk://#diff-be09807abb544c94b592d8832aa39bfd5e144f45edc5a9c809a5246bed69688cL542-R552)

**PIV applet improvements:**

* Introduced the `piv_7c_wrap` function to handle TLV wrapping for responses, replacing repeated manual header construction in `piv_general_authenticate` and reducing the risk of encoding errors. [[1]](diffhunk://#diff-7aba9e1cf7197fa65361c5fd61a77124bc1b1d0bb62435a9472f1ab9dd16861aR70-R95) [[2]](diffhunk://#diff-7aba9e1cf7197fa65361c5fd61a77124bc1b1d0bb62435a9472f1ab9dd16861aL651-R677) [[3]](diffhunk://#diff-7aba9e1cf7197fa65361c5fd61a77124bc1b1d0bb62435a9472f1ab9dd16861aL681-R699) [[4]](diffhunk://#diff-7aba9e1cf7197fa65361c5fd61a77124bc1b1d0bb62435a9472f1ab9dd16861aL705-L710) [[5]](diffhunk://#diff-7aba9e1cf7197fa65361c5fd61a77124bc1b1d0bb62435a9472f1ab9dd16861aL756-R766) [[6]](diffhunk://#diff-7aba9e1cf7197fa65361c5fd61a77124bc1b1d0bb62435a9472f1ab9dd16861aL791-R797)

Results (measured on x86-64, -Os, DEBUG_OUTPUT=OFF, .text section only):

| File | Before | After | Delta |
| ---- | ------ | ----- | ----- |
| ctap.c.o | 19,690 | 18,042 | −1,648 |
| oath.c.o | 6,611 | 6,175 | −436 |
| piv.c.o | 8,484 | 8,356 | −128 |
| openpgp.c.o | 9,524 | 9,397 | −127 |
| key.c.o | 3,468 | 3,244 | −224 |
| Total (all .o) | ~123.2 KB | ~118.3 KB | −2,563 B (−2.1%) |