### PR TITLE
Refactor CTAP for optimized CBOR handling and shared logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,23 @@ if(DEFINED PRODUCT_NAME)
     add_definitions(-DUSBD_PRODUCT_STRING="${PRODUCT_NAME}")
 endif()
 
+# Generate pre-encoded CBOR segments for ctap_get_info.
+# Constants are parsed directly from headers — no duplication.
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+execute_process(
+    COMMAND ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_ctap_get_info.py
+        --headers
+            ${CMAKE_CURRENT_SOURCE_DIR}/applets/ctap/ctap-internal.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/interfaces/USB/class/ctaphid/ctaphid.h
+        --credential-id-size 70
+        --output ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
+    RESULT_VARIABLE GEN_RESULT
+)
+if(NOT GEN_RESULT EQUAL 0)
+    message(FATAL_ERROR "Failed to generate ctap_get_info CBOR template")
+endif()
+
 file(
     GLOB_RECURSE SRC
     src/*.c
@@ -81,6 +98,7 @@ target_include_directories(
         littlefs
         tinycbor/src
         ${CMAKE_CURRENT_BINARY_DIR}/tinycbor
+        ${CMAKE_CURRENT_BINARY_DIR}
         interfaces/USB/device
         interfaces/USB/core/inc
         interfaces/USB/class/ccid

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,8 @@ endif()
 # Generate pre-encoded CBOR segments for ctap_get_info.
 # Constants are parsed directly from headers — no duplication.
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
-execute_process(
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
     COMMAND ${Python3_EXECUTABLE}
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_ctap_get_info.py
         --headers
@@ -61,11 +62,16 @@ execute_process(
             ${CMAKE_CURRENT_SOURCE_DIR}/interfaces/USB/class/ctaphid/ctaphid.h
         --credential-id-size 70
         --output ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
-    RESULT_VARIABLE GEN_RESULT
+    DEPENDS
+        ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_ctap_get_info.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/applets/ctap/ctap-internal.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/interfaces/USB/class/ctaphid/ctaphid.h
+    COMMENT "Generating ctap_get_info_cbor.inc"
 )
-if(NOT GEN_RESULT EQUAL 0)
-    message(FATAL_ERROR "Failed to generate ctap_get_info CBOR template")
-endif()
+add_custom_target(
+    generate_ctap_get_info_cbor
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
+)
 
 file(
     GLOB_RECURSE SRC
@@ -78,6 +84,7 @@ file(
     tinycbor/src/cborparser.c
 )
 add_library(canokey-core ${SRC})
+add_dependencies(canokey-core generate_ctap_get_info_cbor)
 
 if(ENABLE_TESTS)
     target_compile_definitions(canokey-core PUBLIC TEST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,10 @@ endif()
 
 # Generate pre-encoded CBOR segments for ctap_get_info.
 # Constants are parsed directly from headers — no duplication.
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
+find_program(PYTHON_EXE NAMES python3 python REQUIRED)
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
-    COMMAND ${Python3_EXECUTABLE}
+    COMMAND ${PYTHON_EXE}
         ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_ctap_get_info.py
         --headers
             ${CMAKE_CURRENT_SOURCE_DIR}/applets/ctap/ctap-internal.h

--- a/FIDO2 Conformance Testing.json
+++ b/FIDO2 Conformance Testing.json
@@ -14,30 +14,56 @@
             "minor": 0
         }
     ],
-    "authenticationAlgorithms": ["secp256r1_ecdsa_sha256_raw", "ed25519_eddsa_sha512_raw"],
-    "publicKeyAlgAndEncodings": ["cose"],
-    "attestationTypes": ["basic_full"],
+    "authenticationAlgorithms": [
+        "secp256r1_ecdsa_sha256_raw",
+        "ed25519_eddsa_sha512_raw"
+    ],
+    "publicKeyAlgAndEncodings": [
+        "cose"
+    ],
+    "attestationTypes": [
+        "basic_full"
+    ],
     "userVerificationDetails": [
         [
-            { "userVerificationMethod": "none" }
+            {
+                "userVerificationMethod": "none"
+            }
         ],
         [
-            { "userVerificationMethod": "presence_internal" }
+            {
+                "userVerificationMethod": "presence_internal"
+            }
         ],
         [
-            { "userVerificationMethod": "passcode_external" }
+            {
+                "userVerificationMethod": "passcode_external"
+            }
         ],
         [
-            { "userVerificationMethod": "passcode_external" },
-            { "userVerificationMethod": "presence_internal" }
+            {
+                "userVerificationMethod": "passcode_external"
+            },
+            {
+                "userVerificationMethod": "presence_internal"
+            }
         ]
     ],
-    "keyProtection": ["hardware", "secure_element"],
-    "matcherProtection": ["on_chip"],
-    "attachmentHint": ["external", "wired", "nfc"],
+    "keyProtection": [
+        "hardware",
+        "secure_element"
+    ],
+    "matcherProtection": [
+        "on_chip"
+    ],
+    "attachmentHint": [
+        "external",
+        "wired",
+        "nfc"
+    ],
     "tcDisplay": [],
     "attestationRootCertificates": [
-        "MIIBpzCCAUygAwIBAgIUatn9Rj8uCMjLrmFfCQYY5/X9xq4wCgYIKoZIzj0EAwIw\nMTEvMC0GA1UEAwwmQ2Fub0tleXMgRklETyBBdHRlc3RhdGlvbiBSb290IENBIE5v\nLjIwHhcNMjExMjI3MTE0OTMzWhcNNDEwNjI1MTE0OTMzWjAxMS8wLQYDVQQDDCZD\nYW5vS2V5cyBGSURPIEF0dGVzdGF0aW9uIFJvb3QgQ0EgTm8uMjBZMBMGByqGSM49\nAgEGCCqGSM49AwEHA0IABNgW7CwchH80l4sj8luhwjbNoohB9Uqnvsh0SLor18w8\nIMy6rnzzdDP9PgSSbuUZw302mBhyYJqJY1q9Ke0niZujQjBAMB0GA1UdDgQWBBRU\nGAKiwvk2vLP5Zi6ul73RiWyr0jAPBgNVHRMECDAGAQH/AgEAMA4GA1UdDwEB/wQE\nAwIBBjAKBggqhkjOPQQDAgNJADBGAiEAlRNyrmngE3A1YZuwsuwBHLXY7wZC/4CO\nJNA30mtp2+YCIQDA88Pp+Kjx3c4nrgRgSaSueC5IlvwpTSGBGwRYDSdMTA=="
+        "MIIBpzCCAUygAwIBAgIUatn9Rj8uCMjLrmFfCQYY5/X9xq4wCgYIKoZIzj0EAwIwMTEvMC0GA1UEAwwmQ2Fub0tleXMgRklETyBBdHRlc3RhdGlvbiBSb290IENBIE5vLjIwHhcNMjExMjI3MTE0OTMzWhcNNDEwNjI1MTE0OTMzWjAxMS8wLQYDVQQDDCZDYW5vS2V5cyBGSURPIEF0dGVzdGF0aW9uIFJvb3QgQ0EgTm8uMjBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABNgW7CwchH80l4sj8luhwjbNoohB9Uqnvsh0SLor18w8IMy6rnzzdDP9PgSSbuUZw302mBhyYJqJY1q9Ke0niZujQjBAMB0GA1UdDgQWBBRUGAKiwvk2vLP5Zi6ul73RiWyr0jAPBgNVHRMECDAGAQH/AgEAMA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNJADBGAiEAlRNyrmngE3A1YZuwsuwBHLXY7wZC/4COJNA30mtp2+YCIQDA88Pp+Kjx3c4nrgRgSaSueC5IlvwpTSGBGwRYDSdMTA=="
     ],
     "icon": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAACXBIWXMAAC4jAAAuIwF4pT92AAAKT2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AUkSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXXPues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgABeNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAtAGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dXLh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzABhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/phCJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhMWE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQAkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+IoUspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdpr+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZD5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61MbU2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY/R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllirSKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79up+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6VhlWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lOk06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7RyFDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3IveRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+BZ7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5pDoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5qPNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIsOpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQrAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1dT1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aXDm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3SPVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKaRptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfVP1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i/suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADqYAAAOpgAABdvkl/FRgAAAthJREFUeNrslt9Lk1EYx7/vNte0vXOk7yS7qyWBYvnjIktGU0vDCwktV4KXpv3wB/4BBiIa/QC1wjkVUxNsUuuuzd1k6iBLCxIFzcDXOTZwY8r2sr1rp4uXZuoggryJfS8eeL6c53w45+E5HIoQgoOUCAesGCAGiAEAyX6LZdn19XWGYdRq9T8gkN1qa20VDlVZcZUQYpuZKS0tHTca9ywz6Hurq6s/zs6SP2kXwGI2AzjKqHQ63ft3k4SQpoYGAMWFRXvKLmoLAAwODPwdoLdHD2BkaOh3843J5HK59pTV1dwE8Gp8fP+OS4tL5rfmH6GQkO70oLuzc2jwuSop2dBrOCynk5KO9PX3Z2ZkMCkpqyvfGIYBcL+9w2qdKCoqCgQCAHieF2ofP3xkMr1W0IraulptQYHP7wNF7e2BNl8DIO34CQANd+u7u7oASEABqKupJYRU6a4DoGXxqaoUpZwWA9aJCUJI4QUtgFPqkwnSQwD69ProVxQMBtvb2iiKetDRwfN8KBTiOO7Zk6cA+noNLMsCyMo8zfn9HMflnMkCsLS4OD01DUB39RohxOl0yhMS4iiR3W6PbLszB3FxcbRCQQhRJCZKJBKxWCyTyeRyGoBUKv0y/xmATlcpi4+XyWQajQaAz+ebmpwEUF5RDkClUhVqC3gSnp+biz4HnN8PwO/3R5xAgMvNzk5mkkWUCMDq6nfBdzg2BDCtUABwOl2/fIdAig4IBoORKIjneQVNb3m3ii+XiEHp+wzpGelut/ul0QggEAiUXSm7def2vZaWtLS0hYWvH+Y+5Z/Ny8nNjf5USCSSSIw44XDY4dhQKpXDw8NiiqpvbBwdeVF1owoAu7aWmnrM0KPf3t6+VFLc1Nx8Pu/c6NiYSCSKPsket2d5ednj8UQcr9drX7e73ZtCyrJrVqs1HA4TQpZXVrxer+C7N90Wi8Vms+0fCyr2q4gBYoD/APBzAI6VNqGQPUqnAAAAAElFTkSuQmCC",
     "authenticatorGetInfo": {

--- a/FIDO2 Conformance Testing.json
+++ b/FIDO2 Conformance Testing.json
@@ -34,6 +34,7 @@
     ],
     "keyProtection": ["hardware", "secure_element"],
     "matcherProtection": ["on_chip"],
+    "attachmentHint": ["external", "wired", "nfc"],
     "tcDisplay": [],
     "attestationRootCertificates": [
         "MIIBpzCCAUygAwIBAgIUatn9Rj8uCMjLrmFfCQYY5/X9xq4wCgYIKoZIzj0EAwIw\nMTEvMC0GA1UEAwwmQ2Fub0tleXMgRklETyBBdHRlc3RhdGlvbiBSb290IENBIE5v\nLjIwHhcNMjExMjI3MTE0OTMzWhcNNDEwNjI1MTE0OTMzWjAxMS8wLQYDVQQDDCZD\nYW5vS2V5cyBGSURPIEF0dGVzdGF0aW9uIFJvb3QgQ0EgTm8uMjBZMBMGByqGSM49\nAgEGCCqGSM49AwEHA0IABNgW7CwchH80l4sj8luhwjbNoohB9Uqnvsh0SLor18w8\nIMy6rnzzdDP9PgSSbuUZw302mBhyYJqJY1q9Ke0niZujQjBAMB0GA1UdDgQWBBRU\nGAKiwvk2vLP5Zi6ul73RiWyr0jAPBgNVHRMECDAGAQH/AgEAMA4GA1UdDwEB/wQE\nAwIBBjAKBggqhkjOPQQDAgNJADBGAiEAlRNyrmngE3A1YZuwsuwBHLXY7wZC/4CO\nJNA30mtp2+YCIQDA88Pp+Kjx3c4nrgRgSaSueC5IlvwpTSGBGwRYDSdMTA=="

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -1188,9 +1188,12 @@ static uint8_t ctap_get_next_assertion(CborEncoder *encoder) { return ctap_get_a
 static uint8_t ctap_get_info(CborEncoder *encoder) {
   uint8_t *p = encoder->data.ptr;
   uint8_t *end = encoder->end;
+  int sm2_algo = ctap_sm2_attr.algo_id;
+  int sm2_in_alg_list = ctap_sm2_attr.enabled &&
+                        (sm2_algo >= -256 && sm2_algo <= -25);
   size_t need = sizeof(cbor_gi_prefix) + 1 /* array header */
                 + sizeof(cbor_gi_alg_base) + sizeof(cbor_gi_suffix) +
-                (ctap_sm2_attr.enabled ? sizeof(cbor_gi_alg_sm2) : 0);
+                (sm2_in_alg_list ? sizeof(cbor_gi_alg_sm2) : 0);
   if (p + need > end) return CTAP2_ERR_LIMIT_EXCEEDED;
 
   // 1. Prefix: map header through algorithms key
@@ -1199,26 +1202,20 @@ static uint8_t ctap_get_info(CborEncoder *encoder) {
   p += sizeof(cbor_gi_prefix);
 
   // 2. Algorithms array header: 2 or 3 entries
-  *p++ = ctap_sm2_attr.enabled ? 0x83 : 0x82;
+  *p++ = sm2_in_alg_list ? 0x83 : 0x82;
 
   // 3. Base algorithm entries (ES256 + EdDSA)
   memcpy(p, cbor_gi_alg_base, sizeof(cbor_gi_alg_base));
   p += sizeof(cbor_gi_alg_base);
 
   // 4. SM2 entry (conditional)
-  if (ctap_sm2_attr.enabled) {
+  if (sm2_in_alg_list) {
     memcpy(p, cbor_gi_alg_sm2, sizeof(cbor_gi_alg_sm2));
     // Patch SM2 algo_id (CBOR negative int). The CBOR template encodes this
-    // as a 2-byte negative integer (range [-256, -25]), so we must ensure
-    // that the configured value has the same canonical encoding length.
-    int algo = ctap_sm2_attr.algo_id;
-    if (algo < -256 || algo > -25) {
-      // Reject values that would not use the 2-byte encoding; emitting them
-      // would corrupt the surrounding CBOR template.
-      return CTAP2_ERR_INVALID_CBOR;
-    }
+    // as a 2-byte negative integer (range [-256, -25]); we only include SM2
+    // when the configured value matches this canonical encoding length.
     p[CTAP_GI_SM2_ALGO_OFFSET] = 0x38;
-    p[CTAP_GI_SM2_ALGO_OFFSET + 1] = (uint8_t)(-1 - algo);
+    p[CTAP_GI_SM2_ALGO_OFFSET + 1] = (uint8_t)(-1 - sm2_algo);
     p += sizeof(cbor_gi_alg_sm2);
   }
 

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -1204,180 +1204,50 @@ step7:
 // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetNextAssertion
 static uint8_t ctap_get_next_assertion(CborEncoder *encoder) { return ctap_get_assertion(encoder, NULL, 0, true); }
 
+// Pre-encoded CBOR segments for authenticatorGetInfo response.
+// Generated at build time by scripts/gen_ctap_get_info.py.
+// Constants are parsed from headers — see the .inc file for details.
+#include "ctap_get_info_cbor.inc"
+
 static uint8_t ctap_get_info(CborEncoder *encoder) {
-  // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#authenticatorGetInfo
-  CborEncoder map, sub_map;
-  int ret = cbor_encoder_create_map(encoder, &map, 13);
-  CHECK_CBOR_RET(ret);
+  uint8_t *p = encoder->data.ptr;
+  uint8_t *end = encoder->end;
+  size_t need = sizeof(cbor_gi_prefix) + 1 /* array header */
+              + sizeof(cbor_gi_alg_base) + sizeof(cbor_gi_suffix)
+              + (ctap_sm2_attr.enabled ? sizeof(cbor_gi_alg_sm2) : 0);
+  if (p + need > end) return CTAP2_ERR_LIMIT_EXCEEDED;
 
-  // versions
-  ret = cbor_encode_int(&map, GI_RESP_VERSIONS);
-  CHECK_CBOR_RET(ret);
-  CborEncoder array;
-  ret = cbor_encoder_create_array(&map, &array, 3);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_text_stringz(&array, "U2F_V2");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&array, "FIDO_2_0");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&array, "FIDO_2_1");
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&map, &array);
-  CHECK_CBOR_RET(ret);
+  // 1. Prefix: map header through algorithms key
+  memcpy(p, cbor_gi_prefix, sizeof(cbor_gi_prefix));
+  p[CTAP_GI_CLIENT_PIN_OFFSET] = has_pin() ? 0xF5 : 0xF4;
+  p += sizeof(cbor_gi_prefix);
 
-  // extensions
-  ret = cbor_encode_int(&map, GI_RESP_EXTENSIONS);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_array(&map, &array, 4);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_text_stringz(&array, "credBlob");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&array, "credProtect");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&array, "hmac-secret");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&array, "largeBlobKey");
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&map, &array);
-  CHECK_CBOR_RET(ret);
+  // 2. Algorithms array header: 2 or 3 entries
+  *p++ = ctap_sm2_attr.enabled ? 0x83 : 0x82;
 
-  // aaguid
-  ret = cbor_encode_int(&map, GI_RESP_AAGUID);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_byte_string(&map, aaguid, sizeof(aaguid));
-  CHECK_CBOR_RET(ret);
+  // 3. Base algorithm entries (ES256 + EdDSA)
+  memcpy(p, cbor_gi_alg_base, sizeof(cbor_gi_alg_base));
+  p += sizeof(cbor_gi_alg_base);
 
-  // options
-  ret = cbor_encode_int(&map, GI_RESP_OPTIONS);
-  CHECK_CBOR_RET(ret);
-  CborEncoder option_map;
-  ret = cbor_encoder_create_map(&map, &option_map, 6);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_text_stringz(&option_map, "rk");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_boolean(&option_map, true);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&option_map, "credMgmt");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_boolean(&option_map, true);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&option_map, "clientPin");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_boolean(&option_map, has_pin());
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&option_map, "largeBlobs");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_boolean(&option_map, true);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&option_map, "pinUvAuthToken");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_boolean(&option_map, true);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&option_map, "makeCredUvNotRqd");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_boolean(&option_map, true);
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&map, &option_map);
-  CHECK_CBOR_RET(ret);
-
-  // maxMsgSize
-  ret = cbor_encode_int(&map, GI_RESP_MAX_MSG_SIZE);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map, MAX_CTAP_BUFSIZE);
-  CHECK_CBOR_RET(ret);
-
-  // pinUvAuthProtocols
-  ret = cbor_encode_int(&map, GI_RESP_PIN_UV_AUTH_PROTOCOLS);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_array(&map, &array, 2);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_int(&array, 1);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_int(&array, 2);
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&map, &array);
-  CHECK_CBOR_RET(ret);
-
-  // maxCredentialCountInList
-  ret = cbor_encode_int(&map, GI_RESP_MAX_CREDENTIAL_COUNT_IN_LIST);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map, MAX_CREDENTIAL_COUNT_IN_LIST);
-  CHECK_CBOR_RET(ret);
-
-  // maxCredentialIdLength
-  ret = cbor_encode_int(&map, GI_RESP_MAX_CREDENTIAL_ID_LENGTH);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map, sizeof(credential_id));
-  CHECK_CBOR_RET(ret);
-
-  // transports
-  ret = cbor_encode_int(&map, GI_RESP_TRANSPORTS);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_array(&map, &array, 2);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_text_stringz(&array, "nfc");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&array, "usb");
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&map, &array);
-  CHECK_CBOR_RET(ret);
-
-  // algorithms
-  ret = cbor_encode_int(&map, GI_RESP_ALGORITHMS);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_array(&map, &array, ctap_sm2_attr.enabled ? 3 : 2);
-  CHECK_CBOR_RET(ret);
-  {
-    const int algs[] = {COSE_ALG_ES256, COSE_ALG_EDDSA, ctap_sm2_attr.algo_id};
-    int n_algs = ctap_sm2_attr.enabled ? 3 : 2;
-    for (int i = 0; i < n_algs; ++i) {
-      ret = cbor_encoder_create_map(&array, &sub_map, 2);
-      CHECK_CBOR_RET(ret);
-      ret = cbor_encode_text_stringz(&sub_map, "alg");
-      CHECK_CBOR_RET(ret);
-      ret = cbor_encode_int(&sub_map, algs[i]);
-      CHECK_CBOR_RET(ret);
-      ret = cbor_encode_text_stringz(&sub_map, "type");
-      CHECK_CBOR_RET(ret);
-      ret = cbor_encode_text_stringz(&sub_map, "public-key");
-      CHECK_CBOR_RET(ret);
-      ret = cbor_encoder_close_container(&array, &sub_map);
-      CHECK_CBOR_RET(ret);
+  // 4. SM2 entry (conditional)
+  if (ctap_sm2_attr.enabled) {
+    memcpy(p, cbor_gi_alg_sm2, sizeof(cbor_gi_alg_sm2));
+    // Patch SM2 algo_id (CBOR negative int, -1 to -256 range)
+    int algo = ctap_sm2_attr.algo_id;
+    if (algo >= -24 && algo < 0) {
+      p[CTAP_GI_SM2_ALGO_OFFSET] = (uint8_t)(0x20 | (-1 - algo));
+    } else if (algo >= -256 && algo < -24) {
+      p[CTAP_GI_SM2_ALGO_OFFSET] = 0x38;
+      p[CTAP_GI_SM2_ALGO_OFFSET + 1] = (uint8_t)(-1 - algo);
     }
+    p += sizeof(cbor_gi_alg_sm2);
   }
-  ret = cbor_encoder_close_container(&map, &array);
-  CHECK_CBOR_RET(ret);
 
-  // maxSerializedLargeBlobArray
-  ret = cbor_encode_int(&map, GI_RESP_MAX_SERIALIZED_LARGE_BLOB_ARRAY);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map, LARGE_BLOB_SIZE_LIMIT);
-  CHECK_CBOR_RET(ret);
+  // 5. Suffix: remaining fields
+  memcpy(p, cbor_gi_suffix, sizeof(cbor_gi_suffix));
+  p += sizeof(cbor_gi_suffix);
 
-  // firmwareVersion
-  ret = cbor_encode_int(&map, GI_RESP_FIRMWARE_VERSION);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map, FIRMWARE_VERSION);
-  CHECK_CBOR_RET(ret);
-
-  // maxCredBlobLength
-  ret = cbor_encode_int(&map, GI_RESP_MAX_CRED_BLOB_LENGTH);
-  CHECK_CBOR_RET(ret);
-  ret = cbor_encode_int(&map, MAX_CRED_BLOB_LENGTH);
-  CHECK_CBOR_RET(ret);
-
-  ret = cbor_encoder_close_container(encoder, &map);
-  CHECK_CBOR_RET(ret);
+  encoder->data.ptr = p;
   return 0;
 }
 

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -284,6 +284,53 @@ uint8_t ctap_make_auth_data(uint8_t *rp_id_hash, uint8_t *buf, uint8_t flags, co
 }
 
 /**
+ * Encode a PublicKeyCredentialDescriptor: {id: <bytes>, type: "public-key"}
+ */
+static uint8_t cbor_encode_credential_id(CborEncoder *map, const credential_id *cid) {
+  CborEncoder sub_map;
+  int ret = cbor_encoder_create_map(map, &sub_map, 2);
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encode_text_stringz(&sub_map, "id");
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encode_byte_string(&sub_map, (const uint8_t *)cid, sizeof(credential_id));
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encode_text_stringz(&sub_map, "type");
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encode_text_stringz(&sub_map, "public-key");
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encoder_close_container(map, &sub_map);
+  CHECK_CBOR_RET(ret);
+  return 0;
+}
+
+/**
+ * Encode a PublicKeyCredentialUserEntity.
+ * @param detail If true, include name and displayName; otherwise only id.
+ */
+static uint8_t cbor_encode_user_entity(CborEncoder *map, const user_entity *user, bool detail) {
+  CborEncoder sub_map;
+  int ret = cbor_encoder_create_map(map, &sub_map, detail ? 3 : 1);
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encode_text_stringz(&sub_map, "id");
+  CHECK_CBOR_RET(ret);
+  ret = cbor_encode_byte_string(&sub_map, user->id, user->id_size);
+  CHECK_CBOR_RET(ret);
+  if (detail) {
+    ret = cbor_encode_text_stringz(&sub_map, "name");
+    CHECK_CBOR_RET(ret);
+    ret = cbor_encode_text_stringz(&sub_map, user->name);
+    CHECK_CBOR_RET(ret);
+    ret = cbor_encode_text_stringz(&sub_map, "displayName");
+    CHECK_CBOR_RET(ret);
+    ret = cbor_encode_text_stringz(&sub_map, user->display_name);
+    CHECK_CBOR_RET(ret);
+  }
+  ret = cbor_encoder_close_container(map, &sub_map);
+  CHECK_CBOR_RET(ret);
+  return 0;
+}
+
+/**
  * Verify PIN/UV auth token for MC and GA commands.
  * Checks: token validity, permission, RP ID, user verified flag.
  * On success, associates the RP ID with the token.
@@ -992,7 +1039,7 @@ step7:
   if (!check_credential_protect_requirements(&dc.credential_id, ga.allow_list_size > 0, uv))
     return CTAP2_ERR_NO_CREDENTIALS;
 
-  CborEncoder map, sub_map;
+  CborEncoder map;
   uint8_t extension_buffer[MAX_EXTENSION_SIZE_IN_AUTH];
   size_t extension_size = 0;
   uint8_t extension_map_items = (ga.ext_cred_blob ? 1 : 0) +
@@ -1085,19 +1132,7 @@ step7:
   // build credential id
   ret = cbor_encode_int(&map, GA_RESP_CREDENTIAL);
   CHECK_CBOR_RET(ret);
-  ret = cbor_encoder_create_map(&map, &sub_map, 2);
-  CHECK_CBOR_RET(ret);
-  {
-    ret = cbor_encode_text_stringz(&sub_map, "id");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_byte_string(&sub_map, (const uint8_t *)&dc.credential_id, sizeof(credential_id));
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "type");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "public-key");
-    CHECK_CBOR_RET(ret);
-  }
-  ret = cbor_encoder_close_container(&map, &sub_map);
+  ret = cbor_encode_credential_id(&map, &dc.credential_id);
   CHECK_CBOR_RET(ret);
 
   // auth data
@@ -1128,25 +1163,7 @@ step7:
   if (has_user) {
     ret = cbor_encode_int(&map, GA_RESP_PUBLIC_KEY_CREDENTIAL_USER_ENTITY);
     CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_create_map(&map, &sub_map, user_details ? 3 : 1);
-    CHECK_CBOR_RET(ret);
-    {
-      ret = cbor_encode_text_stringz(&sub_map, "id");
-      CHECK_CBOR_RET(ret);
-      ret = cbor_encode_byte_string(&sub_map, dc.user.id, dc.user.id_size);
-      CHECK_CBOR_RET(ret);
-      if (user_details) {
-        ret = cbor_encode_text_stringz(&sub_map, "name");
-        CHECK_CBOR_RET(ret);
-        ret = cbor_encode_text_stringz(&sub_map, dc.user.name);
-        CHECK_CBOR_RET(ret);
-        ret = cbor_encode_text_stringz(&sub_map, "displayName");
-        CHECK_CBOR_RET(ret);
-        ret = cbor_encode_text_stringz(&sub_map, dc.user.display_name);
-        CHECK_CBOR_RET(ret);
-      }
-    }
-    ret = cbor_encoder_close_container(&map, &sub_map);
+    ret = cbor_encode_user_entity(&map, &dc.user, user_details);
     CHECK_CBOR_RET(ret);
   }
 
@@ -1189,11 +1206,9 @@ static uint8_t ctap_get_info(CborEncoder *encoder) {
   uint8_t *p = encoder->data.ptr;
   uint8_t *end = encoder->end;
   int sm2_algo = ctap_sm2_attr.algo_id;
-  int sm2_in_alg_list = ctap_sm2_attr.enabled &&
-                        (sm2_algo >= -256 && sm2_algo <= -25);
+  int sm2_in_alg_list = ctap_sm2_attr.enabled && (sm2_algo >= -256 && sm2_algo <= -25);
   size_t need = sizeof(cbor_gi_prefix) + 1 /* array header */
-                + sizeof(cbor_gi_alg_base) + sizeof(cbor_gi_suffix) +
-                (sm2_in_alg_list ? sizeof(cbor_gi_alg_sm2) : 0);
+                + sizeof(cbor_gi_alg_base) + sizeof(cbor_gi_suffix) + (sm2_in_alg_list ? sizeof(cbor_gi_alg_sm2) : 0);
   if (p + need > end) return CTAP2_ERR_LIMIT_EXCEEDED;
 
   // 1. Prefix: map header through algorithms key
@@ -1619,35 +1634,11 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
     CHECK_CBOR_RET(ret);
     ret = cbor_encode_int(&map, CM_RESP_USER);
     CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_create_map(&map, &sub_map, 3);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "id");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_byte_string(&sub_map, dc.user.id, dc.user.id_size);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "name");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, dc.user.name);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "displayName");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, dc.user.display_name);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_close_container(&map, &sub_map);
+    ret = cbor_encode_user_entity(&map, &dc.user, true);
     CHECK_CBOR_RET(ret);
     ret = cbor_encode_int(&map, CM_RESP_CREDENTIAL_ID);
     CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_create_map(&map, &sub_map, 2);
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "id");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_byte_string(&sub_map, (const uint8_t *)&dc.credential_id, sizeof(credential_id));
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "type");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encode_text_stringz(&sub_map, "public-key");
-    CHECK_CBOR_RET(ret);
-    ret = cbor_encoder_close_container(&map, &sub_map);
+    ret = cbor_encode_credential_id(&map, &dc.credential_id);
     CHECK_CBOR_RET(ret);
     ret = cbor_encode_int(&map, CM_RESP_PUBLIC_KEY);
     CHECK_CBOR_RET(ret);

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -291,8 +291,7 @@ uint8_t ctap_make_auth_data(uint8_t *rp_id_hash, uint8_t *buf, uint8_t flags, co
  * @return 0 on success, CTAP2 error code on failure.
  */
 static uint8_t verify_pin_uv_auth_token(const uint8_t *client_data_hash, const uint8_t *pin_uv_auth_param,
-                                         uint8_t pin_uv_auth_protocol, uint8_t permission,
-                                         const uint8_t *rp_id_hash) {
+                                        uint8_t pin_uv_auth_protocol, uint8_t permission, const uint8_t *rp_id_hash) {
   if (!consecutive_pin_counter) return CTAP2_ERR_PIN_AUTH_BLOCKED;
   if (!cp_verify_pin_token(client_data_hash, CLIENT_DATA_HASH_SIZE, pin_uv_auth_param, pin_uv_auth_protocol)) {
     DBG_MSG("Fail to verify pin token\n");
@@ -416,8 +415,8 @@ static uint8_t ctap_make_credential(CborEncoder *encoder, uint8_t *params, size_
   if (has_pin()) {
     //   11.1 If pin_uv_auth_param parameter is present (implying the "uv" option is false (see Step 5)):
     if (mc.parsed_params & PARAM_PIN_UV_AUTH_PARAM) {
-      uint8_t err = verify_pin_uv_auth_token(mc.client_data_hash, mc.pin_uv_auth_param,
-                                              mc.pin_uv_auth_protocol, CP_PERMISSION_MC, mc.rp_id_hash);
+      uint8_t err = verify_pin_uv_auth_token(mc.client_data_hash, mc.pin_uv_auth_param, mc.pin_uv_auth_protocol,
+                                             CP_PERMISSION_MC, mc.rp_id_hash);
       if (err) return err;
       uv = true;
       DBG_MSG("PIN verified\n");
@@ -830,8 +829,8 @@ static uint8_t ctap_get_assertion(CborEncoder *encoder, uint8_t *params, size_t 
   //    6.2 [N/A] If the "uv" option is present and set to true
   //    6.1 If pin_uv_auth_param parameter is present
   if (has_pin() && (ga.parsed_params & PARAM_PIN_UV_AUTH_PARAM)) {
-    uint8_t err = verify_pin_uv_auth_token(ga.client_data_hash, ga.pin_uv_auth_param,
-                                            ga.pin_uv_auth_protocol, CP_PERMISSION_GA, ga.rp_id_hash);
+    uint8_t err = verify_pin_uv_auth_token(ga.client_data_hash, ga.pin_uv_auth_param, ga.pin_uv_auth_protocol,
+                                           CP_PERMISSION_GA, ga.rp_id_hash);
     if (err) return err;
     uv = true;
   }
@@ -1190,8 +1189,8 @@ static uint8_t ctap_get_info(CborEncoder *encoder) {
   uint8_t *p = encoder->data.ptr;
   uint8_t *end = encoder->end;
   size_t need = sizeof(cbor_gi_prefix) + 1 /* array header */
-              + sizeof(cbor_gi_alg_base) + sizeof(cbor_gi_suffix)
-              + (ctap_sm2_attr.enabled ? sizeof(cbor_gi_alg_sm2) : 0);
+                + sizeof(cbor_gi_alg_base) + sizeof(cbor_gi_suffix) +
+                (ctap_sm2_attr.enabled ? sizeof(cbor_gi_alg_sm2) : 0);
   if (p + need > end) return CTAP2_ERR_LIMIT_EXCEEDED;
 
   // 1. Prefix: map header through algorithms key
@@ -1437,6 +1436,30 @@ static int get_next_slot(uint64_t *slots, uint8_t *numbers) {
   }
   if (idx != -1) *slots &= ~(1ull << idx);
   return idx;
+}
+
+/**
+ * Find a discoverable credential by credential_id.
+ * On success, *dc is filled and *out_idx is set to the file index.
+ *
+ * @return 0 on success, CTAP2 error code on failure.
+ */
+static uint8_t cm_find_credential(const credential_id *target, CTAP_discoverable_credential *dc, int *out_idx) {
+  int size = get_file_size(DC_FILE);
+  if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
+  int n = size / (int)sizeof(CTAP_discoverable_credential);
+  for (int i = 0; i < n; ++i) {
+    size = read_file(DC_FILE, dc, i * (int)sizeof(CTAP_discoverable_credential), sizeof(CTAP_discoverable_credential));
+    if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
+    if (dc->deleted) continue;
+    if (memcmp_s(&dc->credential_id, target, sizeof(credential_id)) == 0) {
+      DBG_MSG("Found, credential_id: ");
+      PRINT_HEX((const uint8_t *)target, sizeof(credential_id));
+      *out_idx = i;
+      return 0;
+    }
+  }
+  return CTAP2_ERR_NO_CREDENTIALS;
 }
 
 static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *params, size_t len) {
@@ -1687,21 +1710,10 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
   case CM_CMD_DELETE_CREDENTIAL:
     if (!cp_verify_rp_id(cm.credential_id.rp_id_hash)) return CTAP2_ERR_PIN_AUTH_INVALID;
     if (numbers == 0) return CTAP2_ERR_NO_CREDENTIALS;
-    size = get_file_size(DC_FILE);
-    if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-    numbers = size / sizeof(CTAP_discoverable_credential);
-    for (idx = 0; idx < numbers; ++idx) {
-      size = read_file(DC_FILE, &dc, idx * (int)sizeof(CTAP_discoverable_credential),
-                       sizeof(CTAP_discoverable_credential));
-      if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-      if (dc.deleted) continue;
-      if (memcmp_s(&dc.credential_id, &cm.credential_id, sizeof(credential_id)) == 0) {
-        DBG_MSG("Found, credential_id: ");
-        PRINT_HEX((const uint8_t *)&dc.credential_id, sizeof(credential_id));
-        break;
-      }
+    {
+      uint8_t err = cm_find_credential(&cm.credential_id, &dc, &idx);
+      if (err) return err;
     }
-    if (idx == numbers) return CTAP2_ERR_NO_CREDENTIALS;
 
     CTAP_dc_general_attr attr;
     if (read_attr(DC_FILE, DC_GENERAL_ATTR, &attr, sizeof(attr)) < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
@@ -1740,25 +1752,10 @@ static uint8_t ctap_credential_management(CborEncoder *encoder, const uint8_t *p
   case CM_CMD_UPDATE_USER_INFORMATION:
     if (!cp_verify_rp_id(cm.credential_id.rp_id_hash)) return CTAP2_ERR_PIN_AUTH_INVALID;
     if (numbers == 0) return CTAP2_ERR_NO_CREDENTIALS;
-    // TODO: refactor this
-    size = get_file_size(DC_FILE);
-    if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-    numbers = size / sizeof(CTAP_discoverable_credential);
     KEEPALIVE();
-    for (idx = 0; idx < numbers; ++idx) {
-      size = read_file(DC_FILE, &dc, idx * (int)sizeof(CTAP_discoverable_credential),
-                       sizeof(CTAP_discoverable_credential));
-      if (size < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-      if (dc.deleted) continue;
-      if (memcmp_s(&dc.credential_id, &cm.credential_id, sizeof(credential_id)) == 0) {
-        DBG_MSG("Found, credential_id: ");
-        PRINT_HEX((const uint8_t *)&dc.credential_id, sizeof(credential_id));
-        break;
-      }
-    }
-    if (idx == numbers) {
-      DBG_MSG("No matching credential\n");
-      return CTAP2_ERR_NO_CREDENTIALS;
+    {
+      uint8_t err = cm_find_credential(&cm.credential_id, &dc, &idx);
+      if (err) return err;
     }
     if (dc.user.id_size != cm.user.id_size || memcmp_s(&dc.user.id, &cm.user.id, dc.user.id_size) != 0) {
       DBG_MSG("Incorrect user id\n");

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -283,6 +283,37 @@ uint8_t ctap_make_auth_data(uint8_t *rp_id_hash, uint8_t *buf, uint8_t flags, co
   return 0;
 }
 
+/**
+ * Verify PIN/UV auth token for MC and GA commands.
+ * Checks: token validity, permission, RP ID, user verified flag.
+ * On success, associates the RP ID with the token.
+ *
+ * @return 0 on success, CTAP2 error code on failure.
+ */
+static uint8_t verify_pin_uv_auth_token(const uint8_t *client_data_hash, const uint8_t *pin_uv_auth_param,
+                                         uint8_t pin_uv_auth_protocol, uint8_t permission,
+                                         const uint8_t *rp_id_hash) {
+  if (!consecutive_pin_counter) return CTAP2_ERR_PIN_AUTH_BLOCKED;
+  if (!cp_verify_pin_token(client_data_hash, CLIENT_DATA_HASH_SIZE, pin_uv_auth_param, pin_uv_auth_protocol)) {
+    DBG_MSG("Fail to verify pin token\n");
+    return CTAP2_ERR_PIN_AUTH_INVALID;
+  }
+  if (!cp_has_permission(permission)) {
+    DBG_MSG("Fail to verify pin permission\n");
+    return CTAP2_ERR_PIN_AUTH_INVALID;
+  }
+  if (!cp_verify_rp_id(rp_id_hash)) {
+    DBG_MSG("Fail to verify pin rp id\n");
+    return CTAP2_ERR_PIN_AUTH_INVALID;
+  }
+  if (!cp_get_user_verified_flag_value()) {
+    DBG_MSG("userVerifiedFlagValue is false\n");
+    return CTAP2_ERR_PIN_AUTH_INVALID;
+  }
+  cp_associate_rp_id(rp_id_hash);
+  return 0;
+}
+
 static uint8_t ctap_make_credential(CborEncoder *encoder, uint8_t *params, size_t len) {
   // https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-makeCred-authnr-alg
   uint8_t data_buf[sizeof(CTAP_auth_data)];
@@ -311,7 +342,7 @@ static uint8_t ctap_make_credential(CborEncoder *encoder, uint8_t *params, size_
   }
 
   // 2. If the pin_uv_auth_param parameter is present
-  //   a. If the pinUvAuthProtocol parameter’s value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
+  //   a. If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
   //     > This has been processed when parsing.
   //   b. If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
   if ((mc.parsed_params & PARAM_PIN_UV_AUTH_PARAM) && !(mc.parsed_params & PARAM_PIN_UV_AUTH_PROTOCOL)) {
@@ -385,38 +416,10 @@ static uint8_t ctap_make_credential(CborEncoder *encoder, uint8_t *params, size_
   if (has_pin()) {
     //   11.1 If pin_uv_auth_param parameter is present (implying the "uv" option is false (see Step 5)):
     if (mc.parsed_params & PARAM_PIN_UV_AUTH_PARAM) {
-      //   a) Call verify(pinUvAuthToken, client_data_hash, pin_uv_auth_param).
-      //      If the verification returns error, then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID error.
-      if (!consecutive_pin_counter) return CTAP2_ERR_PIN_AUTH_BLOCKED;
-      if (!cp_verify_pin_token(mc.client_data_hash, sizeof(mc.client_data_hash), mc.pin_uv_auth_param,
-                               mc.pin_uv_auth_protocol)) {
-        DBG_MSG("Fail to verify pin token\n");
-        return CTAP2_ERR_PIN_AUTH_INVALID;
-      }
-      //   b) Verify that the pinUvAuthToken has the mc permission, if not, then end the operation by returning
-      //   CTAP2_ERR_PIN_AUTH_INVALID.
-      if (!cp_has_permission(CP_PERMISSION_MC)) {
-        DBG_MSG("Fail to verify pin permission\n");
-        return CTAP2_ERR_PIN_AUTH_INVALID;
-      }
-      //   c) If the pinUvAuthToken has a permissions RP ID associated:
-      //      If the permissions RP ID does not match the rp.id in this request, then end the operation by returning
-      //      CTAP2_ERR_PIN_AUTH_INVALID.
-      if (!cp_verify_rp_id(mc.rp_id_hash)) {
-        DBG_MSG("Fail to verify pin rp id\n");
-        return CTAP2_ERR_PIN_AUTH_INVALID;
-      }
-      //   d) Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
-      //   e) If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
-      if (!cp_get_user_verified_flag_value()) {
-        DBG_MSG("userVerifiedFlagValue is false\n");
-        return CTAP2_ERR_PIN_AUTH_INVALID;
-      }
-      //   f) If userVerifiedFlagValue is true then set the "uv" bit to true in the response.
+      uint8_t err = verify_pin_uv_auth_token(mc.client_data_hash, mc.pin_uv_auth_param,
+                                              mc.pin_uv_auth_protocol, CP_PERMISSION_MC, mc.rp_id_hash);
+      if (err) return err;
       uv = true;
-      //   g) If the pinUvAuthToken does not have a permissions RP ID associated:
-      //      Associate the request’s rp.id parameter value with the pinUvAuthToken as its permissions RP ID.
-      cp_associate_rp_id(mc.rp_id_hash);
       DBG_MSG("PIN verified\n");
     }
     //   11.2 [N/A] If the "uv" option is present and set to true
@@ -438,9 +441,9 @@ step12:
       if (ret < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
       if (ret == 0) {
         DBG_MSG("Exclude ID found\n");
-        // a) If the credential’s credProtect value is not userVerificationRequired
+        // a) If the credential's credProtect value is not userVerificationRequired
         if (kh->nonce[CREDENTIAL_NONCE_CP_POS] != CRED_PROTECT_VERIFICATION_REQUIRED ||
-            // b) Else (implying the credential’s credProtect value is userVerificationRequired)
+            // b) Else (implying the credential's credProtect value is userVerificationRequired)
             //    AND If the "uv" bit is true in the response:
             (kh->nonce[CREDENTIAL_NONCE_CP_POS] == CRED_PROTECT_VERIFICATION_REQUIRED && uv)) {
 
@@ -757,7 +760,7 @@ static uint8_t ctap_get_assertion(CborEncoder *encoder, uint8_t *params, size_t 
     //    This step is OPTIONAL if transport is done over NFC.
     if (device_get_tick() - timer > 30000) return CTAP2_ERR_NOT_ALLOWED;
     // 4. Select the credential indexed by credentialCounter. (I.e. credentials[n] assuming a zero-based array.)
-    // 5. Update the response to include the selected credential’s publicKeyCredentialUserEntity information.
+    // 5. Update the response to include the selected credential's publicKeyCredentialUserEntity information.
     //    User identifiable information (name, DisplayName, icon) inside the publicKeyCredentialUserEntity MUST NOT be
     //    returned if user verification was not done by the authenticator in the original authenticatorGetAssertion
     //    call.
@@ -786,7 +789,7 @@ static uint8_t ctap_get_assertion(CborEncoder *encoder, uint8_t *params, size_t 
   }
 
   // 2. If the pin_uv_auth_param parameter is present
-  //   a. If the pinUvAuthProtocol parameter’s value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
+  //   a. If the pinUvAuthProtocol parameter's value is not supported, return CTAP1_ERR_INVALID_PARAMETER error.
   //     > This has been processed when parsing.
   //   b. If the pinUvAuthProtocol parameter is absent, return CTAP2_ERR_MISSING_PARAMETER error.
   if ((ga.parsed_params & PARAM_PIN_UV_AUTH_PARAM) && !(ga.parsed_params & PARAM_PIN_UV_AUTH_PROTOCOL)) {
@@ -827,36 +830,10 @@ static uint8_t ctap_get_assertion(CborEncoder *encoder, uint8_t *params, size_t 
   //    6.2 [N/A] If the "uv" option is present and set to true
   //    6.1 If pin_uv_auth_param parameter is present
   if (has_pin() && (ga.parsed_params & PARAM_PIN_UV_AUTH_PARAM)) {
-    //  a) Call verify(pinUvAuthToken, client_data_hash, pin_uv_auth_param).
-    //     If the verification returns error, return CTAP2_ERR_PIN_AUTH_INVALID error.
-    //     If the verification returns success, set the "uv" bit to true in the response.
-    if (!consecutive_pin_counter) return CTAP2_ERR_PIN_AUTH_BLOCKED;
-    if (!cp_verify_pin_token(ga.client_data_hash, sizeof(ga.client_data_hash), ga.pin_uv_auth_param,
-                             ga.pin_uv_auth_protocol)) {
-      DBG_MSG("Fail to verify pin token\n");
-      return CTAP2_ERR_PIN_AUTH_INVALID;
-    }
+    uint8_t err = verify_pin_uv_auth_token(ga.client_data_hash, ga.pin_uv_auth_param,
+                                            ga.pin_uv_auth_protocol, CP_PERMISSION_GA, ga.rp_id_hash);
+    if (err) return err;
     uv = true;
-    //  b) Let userVerifiedFlagValue be the result of calling getUserVerifiedFlagValue().
-    //  c) If userVerifiedFlagValue is false then end the operation by returning CTAP2_ERR_PIN_AUTH_INVALID.
-    if (!cp_get_user_verified_flag_value()) {
-      DBG_MSG("userVerifiedFlagValue is false\n");
-      return CTAP2_ERR_PIN_AUTH_INVALID;
-    }
-    //  d) Verify that the pinUvAuthToken has the ga permission, if not, return CTAP2_ERR_PIN_AUTH_INVALID.
-    if (!cp_has_permission(CP_PERMISSION_GA)) {
-      DBG_MSG("Fail to verify pin permission\n");
-      return CTAP2_ERR_PIN_AUTH_INVALID;
-    }
-    //  e) If the pinUvAuthToken has a permissions RP ID associated:
-    //     If the permissions RP ID does not match the rp_id in this request, return CTAP2_ERR_PIN_AUTH_INVALID.
-    if (!cp_verify_rp_id(ga.rp_id_hash)) {
-      DBG_MSG("Fail to verify pin rp id\n");
-      return CTAP2_ERR_PIN_AUTH_INVALID;
-    }
-    //  f) If the pinUvAuthToken does not have a permissions RP ID associated:
-    //     Associate the request’s rp_id parameter value with the pinUvAuthToken as its permissions RP ID.
-    cp_associate_rp_id(ga.rp_id_hash);
   }
 
 step7:
@@ -892,7 +869,7 @@ step7:
   //                if transport is done over NFC.
   //           iv. Select the first credential.
   //        3) [N/A] If authenticator has a display and at least one of the "uv" and "up" options is true.
-  //    c) Update the response to include the selected credential’s publicKeyCredentialUserEntity information.
+  //    c) Update the response to include the selected credential's publicKeyCredentialUserEntity information.
   //       User identifiable information (name, DisplayName, icon) inside the publicKeyCredentialUserEntity
   //       MUST NOT be returned if user verification is not done by the authenticator.
   if (ga.allow_list_size > 0) { // Step 11
@@ -1206,7 +1183,7 @@ static uint8_t ctap_get_next_assertion(CborEncoder *encoder) { return ctap_get_a
 
 // Pre-encoded CBOR segments for authenticatorGetInfo response.
 // Generated at build time by scripts/gen_ctap_get_info.py.
-// Constants are parsed from headers — see the .inc file for details.
+// Constants are parsed from headers - see the .inc file for details.
 #include "ctap_get_info_cbor.inc"
 
 static uint8_t ctap_get_info(CborEncoder *encoder) {
@@ -1905,7 +1882,7 @@ static uint8_t ctap_large_blobs(CborEncoder *encoder, const uint8_t *params, siz
       }
       //     iii. If pinUvAuthProtocol is not supported, return CTAP1_ERR_INVALID_PARAMETER.
       //       > Checked when paring.
-      //     iv. The authenticator calls verify(pinUvAuthToken, 32×0xff || h’0c00' || uint32LittleEndian(offset) ||
+      //     iv. The authenticator calls verify(pinUvAuthToken, 32×0xff || h'0c00' || uint32LittleEndian(offset) ||
       //         SHA-256(contents of set byte string, i.e. not including an outer CBOR tag with major type two),
       //         pinUvAuthParam).
       //         If the verification fails, return CTAP2_ERR_PIN_AUTH_INVALID.

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -1208,14 +1208,17 @@ static uint8_t ctap_get_info(CborEncoder *encoder) {
   // 4. SM2 entry (conditional)
   if (ctap_sm2_attr.enabled) {
     memcpy(p, cbor_gi_alg_sm2, sizeof(cbor_gi_alg_sm2));
-    // Patch SM2 algo_id (CBOR negative int, -1 to -256 range)
+    // Patch SM2 algo_id (CBOR negative int). The CBOR template encodes this
+    // as a 2-byte negative integer (range [-256, -25]), so we must ensure
+    // that the configured value has the same canonical encoding length.
     int algo = ctap_sm2_attr.algo_id;
-    if (algo >= -24 && algo < 0) {
-      p[CTAP_GI_SM2_ALGO_OFFSET] = (uint8_t)(0x20 | (-1 - algo));
-    } else if (algo >= -256 && algo < -24) {
-      p[CTAP_GI_SM2_ALGO_OFFSET] = 0x38;
-      p[CTAP_GI_SM2_ALGO_OFFSET + 1] = (uint8_t)(-1 - algo);
+    if (algo < -256 || algo > -25) {
+      // Reject values that would not use the 2-byte encoding; emitting them
+      // would corrupt the surrounding CBOR template.
+      return CTAP2_ERR_INVALID_CBOR;
     }
+    p[CTAP_GI_SM2_ALGO_OFFSET] = 0x38;
+    p[CTAP_GI_SM2_ALGO_OFFSET + 1] = (uint8_t)(-1 - algo);
     p += sizeof(cbor_gi_alg_sm2);
   }
 

--- a/interfaces/USB/class/ctaphid/ctaphid.c
+++ b/interfaces/USB/class/ctaphid/ctaphid.c
@@ -222,6 +222,13 @@ uint8_t CTAPHID_Loop(uint8_t wait_for_user) {
       break;
     case CTAPHID_CANCEL:
       DBG_MSG("CANCEL when wait_for_user=%d\n", (int)wait_for_user);
+      if (wait_for_user) {
+        // A KEEPALIVE frame may still occupy the USB IN endpoint. Wait for
+        // the host to read it so the subsequent error response (sent by the
+        // caller after the call-chain unwinds) is not silently dropped by
+        // USBD_CTAPHID_SendReport's 50 ms busy-wait timeout.
+        USBD_CTAPHID_WaitIdle();
+      }
       ret = LOOP_CANCEL;
       break;
     default:

--- a/interfaces/USB/class/ctaphid/usbd_ctaphid.c
+++ b/interfaces/USB/class/ctaphid/usbd_ctaphid.c
@@ -100,17 +100,26 @@ uint8_t USBD_CTAPHID_DataOut(USBD_HandleTypeDef *pdev) {
   return USBD_OK;
 }
 
+/**
+ * Busy-wait until the USB IN endpoint finishes transmitting, up to max_ms.
+ * Returns USBD_OK if idle, USBD_BUSY on timeout.
+ */
+static uint8_t wait_ep_idle(int max_ms) {
+  volatile CTAPHID_StateTypeDef *state = &hid_handle.state;
+  for (int i = 0; i < max_ms; ++i) {
+    if (*state == CTAPHID_IDLE) return USBD_OK;
+    device_delay(1);
+  }
+  return (*state == CTAPHID_IDLE) ? USBD_OK : USBD_BUSY;
+}
+
 uint8_t USBD_CTAPHID_SendReport(USBD_HandleTypeDef *pdev, uint8_t *report, uint16_t len) {
   if (pdev->dev_state == USBD_STATE_CONFIGURED) {
-    volatile CTAPHID_StateTypeDef *state = &hid_handle.state;
-    int retry = 0;
-    while (*state != CTAPHID_IDLE) {
-      // if reports are not being processed on host, we may get stuck here
-      if (++retry > 50) return USBD_BUSY;
-      device_delay(1);
-    }
+    if (wait_ep_idle(50) != USBD_OK) return USBD_BUSY;
     hid_handle.state = CTAPHID_BUSY;
     USBD_LL_Transmit(pdev, EP_IN(ctap_hid), report, len);
   }
   return USBD_OK;
 }
+
+uint8_t USBD_CTAPHID_WaitIdle(void) { return wait_ep_idle(100); }

--- a/interfaces/USB/class/ctaphid/usbd_ctaphid.h
+++ b/interfaces/USB/class/ctaphid/usbd_ctaphid.h
@@ -23,5 +23,6 @@ uint8_t USBD_CTAPHID_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);
 uint8_t USBD_CTAPHID_DataIn(void);
 uint8_t USBD_CTAPHID_DataOut(USBD_HandleTypeDef *pdev);
 uint8_t USBD_CTAPHID_SendReport(USBD_HandleTypeDef *pdev, uint8_t *report, uint16_t len);
+uint8_t USBD_CTAPHID_WaitIdle(void);
 
 #endif /* __USB_CTAPHID_H */

--- a/scripts/gen_ctap_get_info.py
+++ b/scripts/gen_ctap_get_info.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Generate pre-encoded CBOR segments for ctap_get_info response.
+
+Usage:
+  python3 gen_ctap_get_info.py \
+    --headers ctap-internal.h ctaphid.h \
+    --credential-id-size 70 \
+    --output ctap_get_info_cbor.inc
+
+The script parses #define constants directly from header files.
+Missing constants cause a hard error (no defaults).
+
+Output segments (concatenated at runtime in C):
+  1. cbor_gi_prefix[]     — map header through algorithms key (0x0A)
+  2. cbor_gi_alg_base[]   — ES256 + EdDSA algorithm entries
+  3. cbor_gi_alg_sm2[]    — SM2 algorithm entry (conditional)
+  4. cbor_gi_suffix[]     — remaining fields after algorithms
+
+Dynamic patches at runtime:
+  - clientPin boolean (1 byte in prefix)
+  - SM2 algo_id (1–2 bytes in SM2 entry)
+  - algorithms array header (1 byte, 0x82 or 0x83)
+"""
+
+import argparse
+import re
+import struct
+import sys
+
+
+# --- Parse #define from C headers ---
+
+def parse_defines(header_paths, needed):
+    """Parse integer #define values from C headers.
+    
+    Args:
+        header_paths: list of header file paths to scan
+        needed: dict of {name: None} — filled in with parsed values
+    
+    Returns dict {name: int_value}. Raises if any needed key is missing.
+    """
+    # Match: #define NAME value  (decimal, hex, or negative)
+    pattern = re.compile(r'^\s*#define\s+(\w+)\s+(-?(?:0[xX][0-9a-fA-F]+|\d+))\b')
+    found = {}
+    for path in header_paths:
+        with open(path) as f:
+            for line in f:
+                m = pattern.match(line)
+                if m and m.group(1) in needed:
+                    val_str = m.group(2)
+                    found[m.group(1)] = int(val_str, 0)
+
+    missing = [k for k in needed if k not in found]
+    if missing:
+        print(f"ERROR: missing #define constants: {', '.join(missing)}", file=sys.stderr)
+        print(f"  Searched in: {', '.join(header_paths)}", file=sys.stderr)
+        sys.exit(1)
+
+    return found
+
+
+# --- Minimal CBOR encoder (no dependencies) ---
+
+def encode_uint(n):
+    if n <= 23:
+        return bytes([n])
+    elif n <= 0xFF:
+        return bytes([0x18, n])
+    elif n <= 0xFFFF:
+        return bytes([0x19, (n >> 8) & 0xFF, n & 0xFF])
+    elif n <= 0xFFFFFFFF:
+        return struct.pack('>BI', 0x1A, n)
+    else:
+        return struct.pack('>BQ', 0x1B, n)
+
+
+def encode_int(n):
+    if n >= 0:
+        return encode_uint(n)
+    # Negative: major type 1, value = -1 - n
+    v = -1 - n
+    if v <= 23:
+        return bytes([0x20 | v])
+    elif v <= 0xFF:
+        return bytes([0x38, v])
+    elif v <= 0xFFFF:
+        return bytes([0x39, (v >> 8) & 0xFF, v & 0xFF])
+    else:
+        raise ValueError(f"Negative int too large: {n}")
+
+
+def encode_text(s):
+    b = s.encode('utf-8')
+    if len(b) <= 23:
+        return bytes([0x60 | len(b)]) + b
+    elif len(b) <= 0xFF:
+        return bytes([0x78, len(b)]) + b
+    else:
+        return bytes([0x79, (len(b) >> 8) & 0xFF, len(b) & 0xFF]) + b
+
+
+def encode_bytes(b):
+    if len(b) <= 23:
+        return bytes([0x40 | len(b)]) + b
+    elif len(b) <= 0xFF:
+        return bytes([0x58, len(b)]) + b
+    else:
+        return bytes([0x59, (len(b) >> 8) & 0xFF, len(b) & 0xFF]) + b
+
+
+def encode_bool(v):
+    return bytes([0xF5 if v else 0xF4])
+
+
+def encode_array_header(n):
+    return bytes([0x80 | n]) if n <= 23 else bytes([0x98, n])
+
+
+def encode_map_header(n):
+    return bytes([0xA0 | n]) if n <= 23 else bytes([0xB8, n])
+
+
+# --- Constants ---
+
+GI_VERSIONS = 0x01
+GI_EXTENSIONS = 0x02
+GI_AAGUID = 0x03
+GI_OPTIONS = 0x04
+GI_MAX_MSG_SIZE = 0x05
+GI_PIN_UV_AUTH_PROTOCOLS = 0x06
+GI_MAX_CREDENTIAL_COUNT = 0x07
+GI_MAX_CREDENTIAL_ID_LENGTH = 0x08
+GI_TRANSPORTS = 0x09
+GI_ALGORITHMS = 0x0A
+GI_MAX_SERIALIZED_LARGE_BLOB = 0x0B
+GI_FIRMWARE_VERSION = 0x0E
+GI_MAX_CRED_BLOB_LENGTH = 0x0F
+
+COSE_ALG_ES256 = -7
+COSE_ALG_EDDSA = -8
+
+AAGUID = bytes([0x24, 0x4e, 0xb2, 0x9e, 0xe0, 0x90, 0x4e, 0x49,
+                0x81, 0xfe, 0x1f, 0x20, 0xf8, 0xd3, 0xb8, 0xf4])
+
+
+def build_algorithm_entry(alg_id):
+    return (encode_map_header(2) +
+            encode_text("alg") + encode_int(alg_id) +
+            encode_text("type") + encode_text("public-key"))
+
+
+def build_segments(consts, sm2_algo_id):
+    """Build the four CBOR segments.
+    
+    Returns (prefix, alg_base, alg_sm2, suffix, client_pin_offset, sm2_algo_offset).
+    """
+    # --- Segment 1: prefix (map header through algorithms key) ---
+    prefix = bytearray()
+
+    # Top-level map: 13 entries
+    prefix += encode_map_header(13)
+
+    # 1. versions
+    prefix += encode_uint(GI_VERSIONS)
+    prefix += encode_array_header(3)
+    prefix += encode_text("U2F_V2")
+    prefix += encode_text("FIDO_2_0")
+    prefix += encode_text("FIDO_2_1")
+
+    # 2. extensions
+    prefix += encode_uint(GI_EXTENSIONS)
+    prefix += encode_array_header(4)
+    prefix += encode_text("credBlob")
+    prefix += encode_text("credProtect")
+    prefix += encode_text("hmac-secret")
+    prefix += encode_text("largeBlobKey")
+
+    # 3. aaguid
+    prefix += encode_uint(GI_AAGUID)
+    prefix += encode_bytes(AAGUID)
+
+    # 4. options
+    prefix += encode_uint(GI_OPTIONS)
+    prefix += encode_map_header(6)
+    prefix += encode_text("rk") + encode_bool(True)
+    prefix += encode_text("credMgmt") + encode_bool(True)
+    prefix += encode_text("clientPin")
+    client_pin_offset = len(prefix)
+    prefix += encode_bool(False)  # patched at runtime
+    prefix += encode_text("largeBlobs") + encode_bool(True)
+    prefix += encode_text("pinUvAuthToken") + encode_bool(True)
+    prefix += encode_text("makeCredUvNotRqd") + encode_bool(True)
+
+    # 5. maxMsgSize
+    prefix += encode_uint(GI_MAX_MSG_SIZE)
+    prefix += encode_uint(consts['MAX_CTAP_BUFSIZE'])
+
+    # 6. pinUvAuthProtocols
+    prefix += encode_uint(GI_PIN_UV_AUTH_PROTOCOLS)
+    prefix += encode_array_header(2)
+    prefix += encode_uint(1)
+    prefix += encode_uint(2)
+
+    # 7. maxCredentialCountInList
+    prefix += encode_uint(GI_MAX_CREDENTIAL_COUNT)
+    prefix += encode_uint(consts['MAX_CREDENTIAL_COUNT_IN_LIST'])
+
+    # 8. maxCredentialIdLength
+    prefix += encode_uint(GI_MAX_CREDENTIAL_ID_LENGTH)
+    prefix += encode_uint(consts['CREDENTIAL_ID_SIZE'])
+
+    # 9. transports
+    prefix += encode_uint(GI_TRANSPORTS)
+    prefix += encode_array_header(2)
+    prefix += encode_text("nfc")
+    prefix += encode_text("usb")
+
+    # 10. algorithms key only (array header emitted at runtime)
+    prefix += encode_uint(GI_ALGORITHMS)
+
+    # --- Segment 2: base algorithm entries (ES256 + EdDSA) ---
+    alg_base = bytearray()
+    alg_base += build_algorithm_entry(COSE_ALG_ES256)
+    alg_base += build_algorithm_entry(COSE_ALG_EDDSA)
+
+    # --- Segment 3: SM2 algorithm entry ---
+    alg_sm2 = bytearray()
+    alg_sm2_entry = build_algorithm_entry(sm2_algo_id)
+    # Find the algo_id byte offset within this entry
+    # Entry: map(2){text("alg"), int(algo_id), text("type"), text("public-key")}
+    # map_header(1) + text("alg")(4) = 5 bytes, then the int encoding
+    sm2_algo_offset = 1 + len(encode_text("alg"))
+    alg_sm2 += alg_sm2_entry
+
+    # --- Segment 4: suffix (remaining fields) ---
+    suffix = bytearray()
+
+    # 11. maxSerializedLargeBlobArray
+    suffix += encode_uint(GI_MAX_SERIALIZED_LARGE_BLOB)
+    suffix += encode_uint(consts['LARGE_BLOB_SIZE_LIMIT'])
+
+    # 12. firmwareVersion
+    suffix += encode_uint(GI_FIRMWARE_VERSION)
+    suffix += encode_uint(consts['FIRMWARE_VERSION'])
+
+    # 13. maxCredBlobLength
+    suffix += encode_uint(GI_MAX_CRED_BLOB_LENGTH)
+    suffix += encode_uint(consts['MAX_CRED_BLOB_LENGTH'])
+
+    return (bytes(prefix), bytes(alg_base), bytes(alg_sm2), bytes(suffix),
+            client_pin_offset, sm2_algo_offset)
+
+
+def format_c_array(data):
+    lines = []
+    for i in range(0, len(data), 16):
+        chunk = data[i:i+16]
+        hex_str = ", ".join(f"0x{b:02X}" for b in chunk)
+        lines.append(f"  {hex_str},")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate CBOR segments for ctap_get_info")
+    parser.add_argument("--headers", nargs="+", required=True,
+                        help="C header files to parse for #define constants")
+    parser.add_argument("--credential-id-size", type=int, required=True,
+                        help="sizeof(credential_id) — not a #define, passed from CMake")
+    parser.add_argument("--sm2-algo-id", type=int, default=-48)
+    parser.add_argument("--output", type=str, required=True)
+    args = parser.parse_args()
+
+    # Constants we need from headers
+    needed = {
+        'FIRMWARE_VERSION': None,
+        'MAX_CTAP_BUFSIZE': None,
+        'MAX_CREDENTIAL_COUNT_IN_LIST': None,
+        'LARGE_BLOB_SIZE_LIMIT': None,
+        'MAX_CRED_BLOB_LENGTH': None,
+    }
+    consts = parse_defines(args.headers, needed)
+    consts['CREDENTIAL_ID_SIZE'] = args.credential_id_size
+
+    prefix, alg_base, alg_sm2, suffix, pin_off, sm2_algo_off = \
+        build_segments(consts, args.sm2_algo_id)
+
+    total_no_sm2 = len(prefix) + 1 + len(alg_base) + len(suffix)
+    total_sm2 = len(prefix) + 1 + len(alg_base) + len(alg_sm2) + len(suffix)
+
+    with open(args.output, 'w') as f:
+        f.write("// Auto-generated by scripts/gen_ctap_get_info.py — DO NOT EDIT\n")
+        f.write("// Re-generate: cmake reconfigure (constants parsed from headers)\n")
+        f.write("//\n")
+        f.write(f"// Parsed constants:\n")
+        for k, v in sorted(consts.items()):
+            f.write(f"//   {k} = {v}\n")
+        f.write(f"//   sm2_algo_id = {args.sm2_algo_id} (default, patched at runtime)\n")
+        f.write(f"//\n")
+        f.write(f"// Total response size: {total_no_sm2} bytes (no SM2), "
+                f"{total_sm2} bytes (with SM2)\n\n")
+
+        f.write(f"// Byte offset of clientPin boolean within cbor_gi_prefix\n")
+        f.write(f"#define CTAP_GI_CLIENT_PIN_OFFSET {pin_off}\n")
+        f.write(f"// Byte offset of SM2 algo_id within cbor_gi_alg_sm2\n")
+        f.write(f"#define CTAP_GI_SM2_ALGO_OFFSET {sm2_algo_off}\n")
+        f.write(f"// SM2 algo_id encoding length in default template\n")
+        sm2_enc_len = len(build_algorithm_entry(args.sm2_algo_id)) - \
+                      len(build_algorithm_entry(0))  # diff is just the int encoding
+        # Actually, easier: just record the encoding length of the default algo_id
+        from_offset = sm2_algo_off
+        default_enc = bytearray(alg_sm2[from_offset:])
+        # Find where "type" text starts after the int
+        type_text = encode_text("type")
+        type_pos = alg_sm2.index(bytes(type_text), from_offset)
+        default_algo_enc_len = type_pos - from_offset
+        f.write(f"#define CTAP_GI_SM2_ALGO_ENC_LEN {default_algo_enc_len}\n\n")
+
+        f.write(f"// Segment 1: map header through algorithms key ({len(prefix)} bytes)\n")
+        f.write(f"// clientPin boolean is at offset {pin_off}\n")
+        f.write(f"static const uint8_t cbor_gi_prefix[{len(prefix)}] = {{\n")
+        f.write(format_c_array(prefix))
+        f.write(f"\n}};\n\n")
+
+        f.write(f"// Segment 2: ES256 + EdDSA algorithm entries ({len(alg_base)} bytes)\n")
+        f.write(f"static const uint8_t cbor_gi_alg_base[{len(alg_base)}] = {{\n")
+        f.write(format_c_array(alg_base))
+        f.write(f"\n}};\n\n")
+
+        f.write(f"// Segment 3: SM2 algorithm entry ({len(alg_sm2)} bytes)\n")
+        f.write(f"// algo_id at offset {sm2_algo_off}, {default_algo_enc_len} byte(s)\n")
+        f.write(f"static const uint8_t cbor_gi_alg_sm2[{len(alg_sm2)}] = {{\n")
+        f.write(format_c_array(alg_sm2))
+        f.write(f"\n}};\n\n")
+
+        f.write(f"// Segment 4: remaining fields after algorithms ({len(suffix)} bytes)\n")
+        f.write(f"static const uint8_t cbor_gi_suffix[{len(suffix)}] = {{\n")
+        f.write(format_c_array(suffix))
+        f.write(f"\n}};\n")
+
+    print(f"Generated {args.output}:")
+    print(f"  prefix:   {len(prefix)} bytes (clientPin at offset {pin_off})")
+    print(f"  alg_base: {len(alg_base)} bytes")
+    print(f"  alg_sm2:  {len(alg_sm2)} bytes (algo_id at offset {sm2_algo_off})")
+    print(f"  suffix:   {len(suffix)} bytes")
+    print(f"  Total:    {total_no_sm2} / {total_sm2} bytes (no SM2 / SM2)")
+    print(f"  Constants parsed from: {', '.join(args.headers)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gen_ctap_get_info.py
+++ b/scripts/gen_ctap_get_info.py
@@ -304,11 +304,9 @@ def main():
         f.write(f"// Byte offset of SM2 algo_id within cbor_gi_alg_sm2\n")
         f.write(f"#define CTAP_GI_SM2_ALGO_OFFSET {sm2_algo_off}\n")
         f.write(f"// SM2 algo_id encoding length in default template\n")
-        sm2_enc_len = len(build_algorithm_entry(args.sm2_algo_id)) - \
-                      len(build_algorithm_entry(0))  # diff is just the int encoding
-        # Actually, easier: just record the encoding length of the default algo_id
+        # Record the encoding length of the default algo_id by locating where the
+        # \"type\" text key starts after the integer encoding.
         from_offset = sm2_algo_off
-        default_enc = bytearray(alg_sm2[from_offset:])
         # Find where "type" text starts after the int
         type_text = encode_text("type")
         type_pos = alg_sm2.index(bytes(type_text), from_offset)

--- a/test-via-pcsc/install_gpg.sh
+++ b/test-via-pcsc/install_gpg.sh
@@ -14,9 +14,9 @@ pcsc-driver /usr/lib/x86_64-linux-gnu/libpcsclite.so.1
 disable-ccid
 EOF
 
-pushd gnupg/pinentry-1.2.1
-sudo make install
-popd
+# Copy the pre-built binary directly — avoid `make install` which
+# recurses into all subdirs (gnome3, etc.) and triggers recompilation.
+sudo install -m 755 gnupg/pinentry-1.2.1/tty/pinentry-tty /usr/local/bin/pinentry-tty
 
 sudo ln -sf /usr/local/bin/pinentry-tty /usr/bin/pinentry
 gpg-connect-agent reloadagent /bye || true

--- a/test-via-pcsc/install_gpg.sh
+++ b/test-via-pcsc/install_gpg.sh
@@ -2,6 +2,10 @@
 # Install patched pinentry-tty + configure gpg-agent (runs every time)
 set -e
 
+# install then remove, only for its dependencies
+sudo apt-get install -q -y pinentry-tty libsecret-1-0
+sudo apt-get remove -q -y pinentry-tty
+
 mkdir -m 700 ~/.gnupg || true
 cat >~/.gnupg/gpg-agent.conf <<EOF
 pinentry-program /usr/local/bin/pinentry-tty
@@ -17,6 +21,7 @@ EOF
 # Copy the pre-built binary directly — avoid `make install` which
 # recurses into all subdirs (gnome3, etc.) and triggers recompilation.
 sudo install -m 755 gnupg/pinentry-1.2.1/tty/pinentry-tty /usr/local/bin/pinentry-tty
+/usr/local/bin/pinentry-tty --version
 
 sudo ln -sf /usr/local/bin/pinentry-tty /usr/bin/pinentry
 gpg-connect-agent reloadagent /bye || true


### PR DESCRIPTION
This pull request introduces several improvements to the CTAP (Client to Authenticator Protocol) implementation, focusing on maintainability, efficiency, and code clarity. The most significant changes include generating the `authenticatorGetInfo` CBOR response at build time to avoid runtime encoding, refactoring repeated PIN/UV token verification logic into a helper function, and improving credential management code reuse.

**Build process and code generation:**
- Added a build step in `CMakeLists.txt` to generate pre-encoded CBOR segments for the `ctap_get_info` response using a Python script, reducing runtime overhead and eliminating duplication of constants. The generated file is now included in the build and source paths. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR53-R69) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR101)

**CTAP command handler refactoring:**
- Replaced the manual CBOR encoding in `ctap_get_info` with the inclusion of pre-encoded CBOR data, patching only the necessary fields at runtime (e.g., PIN presence and algorithm list). This significantly simplifies the function and improves performance.
- Introduced a new helper function `verify_pin_uv_auth_token` to centralize and streamline PIN/UV token validation logic for both MakeCredential and GetAssertion commands, replacing repeated inline checks. [[1]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761R286-R315) [[2]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L388-L419) [[3]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L830-L859)

**Credential management improvements:**
- Added a helper function `cm_find_credential` to encapsulate the logic for searching discoverable credentials by ID, improving code reuse and clarity. Updated the credential deletion logic to use this helper. [[1]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761R1441-R1464) [[2]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1843-L1857)

**Minor improvements and consistency:**
- Standardized comments and string literals for consistency (e.g., using "credential's" instead of "credential’s"). [[1]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L314-R344) [[2]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L441-R445) [[3]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L760-R762) [[4]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L789-R791) [[5]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L895-R871)

These changes collectively make the codebase easier to maintain, more efficient, and less error-prone by reducing duplication and centralizing key logic.

**References:**  
[[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR53-R69) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR101) [[3]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1207-R1226) [[4]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761R286-R315) [[5]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L388-L419) [[6]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L830-L859) [[7]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761R1441-R1464) [[8]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L1843-L1857) [[9]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L314-R344) [[10]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L441-R445) [[11]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L760-R762) [[12]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L789-R791) [[13]](diffhunk://#diff-9e7c3481d8f3d5ddf4da27fb4a58cfd274e38d0e3c44c9be377abb7abe928761L895-R871)