### PR TITLE
Refactor: add ENABLE_NFC switch to conditionally compile NFC code

### DIFF
--- a/applets/ndef/ndef.c
+++ b/applets/ndef/ndef.c
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <common.h>
 #include <ndef.h>
+
+#if ENABLE_NFC
+
+#include <common.h>
 
 #define CC_FILE "E103" // file identifier also 0xE103
 #define NDEF_FILE "NDEF"
@@ -145,3 +148,5 @@ int ndef_process_apdu(const CAPDU *capdu, RAPDU *rapdu) {
   if (ret < 0) EXCEPT(SW_UNABLE_TO_PROCESS);
   return 0;
 }
+
+#endif // ENABLE_NFC

--- a/include/device.h
+++ b/include/device.h
@@ -98,8 +98,13 @@ uint8_t wait_for_user_presence(uint8_t entry);
 int strong_user_presence_test(void);
 int send_keepalive_during_processing(uint8_t entry);
 void device_loop(void);
+#if ENABLE_NFC
 uint8_t is_nfc(void);
 void set_nfc_state(uint8_t state);
+#else
+static inline uint8_t is_nfc(void) { return 0; }
+static inline void set_nfc_state(uint8_t state) { (void)state; }
+#endif
 uint8_t get_touch_result(void);
 void set_touch_result(uint8_t result);
 void device_update_led(void);
@@ -119,6 +124,7 @@ void device_init(void);
 void stop_blinking(void);
 uint8_t device_is_blinking(void);
 bool device_allow_kbd_touch(void);
+#if ENABLE_NFC
 void fm11_init(void);
 fm_status_t fm_read_regs(uint16_t reg, uint8_t *buf, uint8_t len);
 fm_status_t fm_write_regs(uint16_t reg, const uint8_t *buf, uint8_t len);
@@ -130,6 +136,9 @@ fm_status_t fm_write_fifo(uint8_t *buf, uint8_t len);
 fm_status_t fm11nt_read(uint16_t addr, uint8_t *buf, uint8_t len);
 fm_status_t fm11nt_write(uint16_t addr, const uint8_t *buf, uint8_t len);
 uint8_t fm_crc8(const uint8_t *data, const uint8_t data_length);
+#endif
+#else
+static inline void fm11_init(void) {}
 #endif
 
 #endif // _DEVICE_H_

--- a/include/ndef.h
+++ b/include/ndef.h
@@ -3,15 +3,35 @@
 #define CANOKEY_CORE_INCLUDE_NDEF_H
 
 #include <apdu.h>
+#include <nfc.h>
 
 #define NDEF_INS_SELECT 0xA4
 #define NDEF_INS_READ_BINARY 0xB0
 #define NDEF_INS_UPDATE 0xD6
 
+#if ENABLE_NFC
 void ndef_poweroff(void);
 int ndef_install(uint8_t reset);
 int ndef_process_apdu(const CAPDU *capdu, RAPDU *rapdu);
 int ndef_get_read_only(void);
 int ndef_toggle_read_only(const CAPDU *capdu, RAPDU *rapdu);
+#else
+static inline void ndef_poweroff(void) {}
+static inline int ndef_install(uint8_t reset) {
+  (void)reset;
+  return 0;
+}
+static inline int ndef_process_apdu(const CAPDU *capdu, RAPDU *rapdu) {
+  (void)capdu;
+  (void)rapdu;
+  return 0;
+}
+static inline int ndef_get_read_only(void) { return 0; }
+static inline int ndef_toggle_read_only(const CAPDU *capdu, RAPDU *rapdu) {
+  (void)capdu;
+  (void)rapdu;
+  return 0;
+}
+#endif
 
 #endif // CANOKEY_CORE_INCLUDE_NDEF_H

--- a/include/nfc.h
+++ b/include/nfc.h
@@ -98,8 +98,18 @@
 #define NFC_STATE_IDLE 0x00
 #define NFC_STATE_BUSY 0x01
 
+#ifndef ENABLE_NFC
+#define ENABLE_NFC 1
+#endif
+
+#if ENABLE_NFC
 void nfc_init(void);
 void nfc_handler(void);
 void nfc_loop(void);
+#else
+static inline void nfc_init(void) {}
+static inline void nfc_handler(void) {}
+static inline void nfc_loop(void) {}
+#endif
 
 #endif // _NFC_H_

--- a/interfaces/NFC/fm.c
+++ b/interfaces/NFC/fm.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "device.h"
+
+#if ENABLE_NFC
+
 #include <stdint.h>
 
 #define I2C_WRITE_WITH_CHECK(data)                                                                                     \
@@ -208,4 +211,6 @@ uint8_t fm_crc8(const uint8_t *data, const uint8_t data_length) {
   return crc8 & 0xff;
 }
 
-#endif
+#endif // NFC_CHIP == NFC_CHIP_FM11NT
+
+#endif // ENABLE_NFC

--- a/interfaces/NFC/nfc.c
+++ b/interfaces/NFC/nfc.c
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "nfc.h"
+
+#if ENABLE_NFC
+
 #include "apdu.h"
 #include "device.h"
 
@@ -201,4 +204,6 @@ void nfc_handler(void) {
   }
 }
 
-#endif
+#endif // NFC_CHIP != NFC_CHIP_NA
+
+#endif // ENABLE_NFC

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -197,11 +197,8 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
       uint8_t i, end = APPLET_ENUM_END;
       for (i = APPLET_NULL + 1; i != end; ++i) {
         if (LC >= AID_Size[i] && memcmp(DATA, AID[i], AID_Size[i]) == 0) {
-          if (0) {
-            (void)0;
-          }
 #if ENABLE_NFC
-          else if (i == APPLET_NDEF && !cfg_is_ndef_enable()) {
+          if (i == APPLET_NDEF && !cfg_is_ndef_enable()) {
             LL = 0;
             SW = SW_FILE_NOT_FOUND;
             DBG_MSG("NDEF is disable\n");

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -18,7 +18,9 @@ enum APPLET {
   APPLET_OATH,
   APPLET_ADMIN,
   APPLET_OPENPGP,
+#if ENABLE_NFC
   APPLET_NDEF,
+#endif
   APPLET_ENUM_END,
 } current_applet;
 
@@ -33,11 +35,16 @@ static const uint8_t OATH_AID[] = {0xA0, 0x00, 0x00, 0x05, 0x27, 0x21, 0x01};
 static const uint8_t ADMIN_AID[] = {0xF0, 0x00, 0x00, 0x00, 0x00};
 static const uint8_t OPENPGP_AID[] = {0xD2, 0x76, 0x00, 0x01, 0x24, 0x01};
 static const uint8_t FIDO_AID[] = {0xA0, 0x00, 0x00, 0x06, 0x47, 0x2F, 0x00, 0x01};
+#if ENABLE_NFC
 static const uint8_t NDEF_AID[] = {0xD2, 0x76, 0x00, 0x00, 0x85, 0x01, 0x01};
+#endif
 
 static const uint8_t *const AID[] = {
-    [APPLET_NULL] = NULL,       [APPLET_PIV] = PIV_AID,         [APPLET_FIDO] = FIDO_AID, [APPLET_OATH] = OATH_AID,
-    [APPLET_ADMIN] = ADMIN_AID, [APPLET_OPENPGP] = OPENPGP_AID, [APPLET_NDEF] = NDEF_AID,
+    [APPLET_NULL] = NULL,     [APPLET_PIV] = PIV_AID,     [APPLET_FIDO] = FIDO_AID,
+    [APPLET_OATH] = OATH_AID, [APPLET_ADMIN] = ADMIN_AID, [APPLET_OPENPGP] = OPENPGP_AID,
+#if ENABLE_NFC
+    [APPLET_NDEF] = NDEF_AID,
+#endif
 };
 
 static const uint8_t AID_Size[] = {
@@ -47,7 +54,9 @@ static const uint8_t AID_Size[] = {
     [APPLET_OATH] = sizeof(OATH_AID),
     [APPLET_ADMIN] = sizeof(ADMIN_AID),
     [APPLET_OPENPGP] = sizeof(OPENPGP_AID),
+#if ENABLE_NFC
     [APPLET_NDEF] = sizeof(NDEF_AID),
+#endif
 };
 
 static volatile uint32_t buffer_owner = BUFFER_OWNER_NONE;
@@ -188,12 +197,17 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
       uint8_t i, end = APPLET_ENUM_END;
       for (i = APPLET_NULL + 1; i != end; ++i) {
         if (LC >= AID_Size[i] && memcmp(DATA, AID[i], AID_Size[i]) == 0) {
-          if (i == APPLET_NDEF && !cfg_is_ndef_enable()) {
+          if (0) {
+            (void)0;
+          }
+#if ENABLE_NFC
+          else if (i == APPLET_NDEF && !cfg_is_ndef_enable()) {
             LL = 0;
             SW = SW_FILE_NOT_FOUND;
             DBG_MSG("NDEF is disable\n");
             return;
           }
+#endif
           if (i == APPLET_PIV) piv_state = PIV_STATE_OTHER; // Reset `piv_state`
           if (i != current_applet) applets_poweroff();
           current_applet = i;
@@ -247,9 +261,11 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
     case APPLET_ADMIN:
       admin_process_apdu(capdu, rapdu);
       break;
+#if ENABLE_NFC
     case APPLET_NDEF:
       ndef_process_apdu(capdu, rapdu);
       break;
+#endif
     default:
       LL = 0;
       SW = SW_FILE_NOT_FOUND;

--- a/src/device.c
+++ b/src/device.c
@@ -8,7 +8,9 @@
 #include <webusb.h>
 
 volatile static uint8_t touch_result;
+#if ENABLE_NFC
 static uint8_t has_rf;
+#endif
 static uint32_t last_blink, blink_timeout, blink_interval;
 static enum { ON, OFF } led_status;
 typedef enum { WAIT_NONE = 1, WAIT_CCID, WAIT_CTAPHID, WAIT_DEEP, WAIT_DEEP_TOUCHED, WAIT_DEEP_CANCEL } wait_status_t;
@@ -128,6 +130,7 @@ __attribute__((weak)) int strong_user_presence_test(void) {
   return 0;
 }
 
+#if ENABLE_NFC
 void set_nfc_state(uint8_t val) { has_rf = val; }
 
 uint8_t is_nfc(void) {
@@ -136,6 +139,7 @@ uint8_t is_nfc(void) {
 #endif
   return has_rf;
 }
+#endif
 
 static void toggle_led(void) {
   if (led_status == ON) {


### PR DESCRIPTION
This pull request introduces conditional compilation for NFC-related functionality throughout the codebase. The main goal is to make NFC features optional, allowing the code to be built and run with or without NFC support, depending on the `ENABLE_NFC` macro. This is achieved by wrapping NFC-specific code in `#if ENABLE_NFC` blocks and providing stub implementations when NFC is disabled. The changes touch multiple files and ensure that the codebase remains robust and maintainable regardless of NFC configuration.

Conditional compilation for NFC features:

* Added `#if ENABLE_NFC` blocks to NFC-related code in `applets/ndef/ndef.c`, `interfaces/NFC/fm.c`, `interfaces/NFC/nfc.c`, and `src/apdu.c`, and provided stub functions when NFC is disabled to ensure compatibility. [[1]](diffhunk://#diff-7d5f49897a28800b85244ac4fb312f39991197e71a731c0056390fcd6c5dd2aaL2-R7) [[2]](diffhunk://#diff-797579e5127f275bbaa8b884acb3637880eb524d955926df379409fb4e54cadfR3-R5) [[3]](diffhunk://#diff-3a35eaea6732bc538fe525eb163e9de9cbde8fe731f64f0f1cca7fcb23a4cf4bR3-R5) [[4]](diffhunk://#diff-4caf1d95e016b5535a2a7feea84f9c43174a08a2e1547bd662090f7d72e25487R21-R23)
* Updated `include/device.h`, `include/ndef.h`, and `include/nfc.h` to wrap NFC-specific function declarations and definitions with conditional compilation, providing inline stubs when disabled. [[1]](diffhunk://#diff-64740803f7fd17de4e55e4bfec0aea28c71bfd71762a5188df5deb479003641aR101-R107) [[2]](diffhunk://#diff-64740803f7fd17de4e55e4bfec0aea28c71bfd71762a5188df5deb479003641aR127) [[3]](diffhunk://#diff-64740803f7fd17de4e55e4bfec0aea28c71bfd71762a5188df5deb479003641aR140-R142) [[4]](diffhunk://#diff-27997b5cd45d7c83e33b13386fd26d1fd713e52d7ee4e51b6e1dfd71c15f592dR6-R35) [[5]](diffhunk://#diff-f42fdee0d0602d28a71072b686d0ccdcf5074a107d2bc9013a13209fb5c43375R101-R113)

NDEF applet integration:

* Modified `src/apdu.c` to conditionally include and process the NDEF applet and its AID only when NFC is enabled, preventing unnecessary code execution and memory usage. [[1]](diffhunk://#diff-4caf1d95e016b5535a2a7feea84f9c43174a08a2e1547bd662090f7d72e25487R38-R47) [[2]](diffhunk://#diff-4caf1d95e016b5535a2a7feea84f9c43174a08a2e1547bd662090f7d72e25487R57-R59) [[3]](diffhunk://#diff-4caf1d95e016b5535a2a7feea84f9c43174a08a2e1547bd662090f7d72e25487L191-R210) [[4]](diffhunk://#diff-4caf1d95e016b5535a2a7feea84f9c43174a08a2e1547bd662090f7d72e25487R264-R268)

NFC state management:

* Added conditional compilation for NFC state variables and functions in `src/device.c`, ensuring that NFC state is only tracked and managed when NFC is enabled. [[1]](diffhunk://#diff-2f2df86bb7d7b0ecba2672917548ba495f1fa2c6cd9792a8c0d63070aa63aad1R11-R13) [[2]](diffhunk://#diff-2f2df86bb7d7b0ecba2672917548ba495f1fa2c6cd9792a8c0d63070aa63aad1R133) [[3]](diffhunk://#diff-2f2df86bb7d7b0ecba2672917548ba495f1fa2c6cd9792a8c0d63070aa63aad1R142)

NFC chip-specific handling:

* Ensured that NFC chip-specific code is also wrapped with `#if ENABLE_NFC` to prevent compilation errors and unnecessary code inclusion when NFC is not used. [[1]](diffhunk://#diff-797579e5127f275bbaa8b884acb3637880eb524d955926df379409fb4e54cadfL211-R216) [[2]](diffhunk://#diff-3a35eaea6732bc538fe525eb163e9de9cbde8fe731f64f0f1cca7fcb23a4cf4bL204-R209)

These changes collectively make the codebase more modular and configurable, allowing builds with or without NFC support as needed.