### PR TITLE
Implement PIV PIN-protected data objects

### DIFF
--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -31,6 +31,7 @@
 #define SECURITY_PATH               "piv-sec"  // security object
 #define KEY_HISTORY_PATH            "piv-kh"   // key history object
 #define IRIS_PATH                   "piv-iris" // card holder iris images
+#define PIV_DO_META_PATH            "piv-do"   // small data object attrs
 // clang-format on
 
 // key tags and path
@@ -80,18 +81,23 @@ static enum PIV_STATE piv_state = PIV_STATE_OTHER;
  *
  * LittleFS metadata blocks are 512 bytes on the target. Do not aggregate
  * several large DO attrs on a single file: attr payloads plus LittleFS metadata
- * tags must fit in that one block. Only the PIN-only objects that are small in
- * normal PIN-only-compatible use live on CARD_ADMIN_KEY_PATH attrs:
+ * tags must fit in that one block. Only the host-managed data objects that are
+ * normally small live on PIV_DO_META_PATH attrs:
  *
  *   - ADMIN DATA, max 128 bytes.
- *   - PRINTED, only while it is <= 64 bytes. The PIN-protected encoding is
- *     30 bytes: 53 1c 88 1a 89 18 <24-byte management key>.
+ *   - PRINTED, only while it is <= 64 bytes. This covers the common 30-byte
+ *     host-managed management-key reference:
+ *     53 1c 88 1a 89 18 <24-byte management key>.
  *
  * The static assert below intentionally caps those attr payloads to half a
- * metadata block, leaving room for key metadata, the default-key attr, LittleFS
- * tag overhead, and future small attrs. Larger PRINTED payloads fall back to
- * PI_PATH. SECURITY and KEY HISTORY are file-backed so they cannot crowd the
- * admin-key metadata block.
+ * metadata block, leaving room for LittleFS tag overhead and future small
+ * attrs. Larger PRINTED payloads fall back to PI_PATH. SECURITY and KEY
+ * HISTORY are file-backed so they cannot crowd the small-DO metadata block.
+ *
+ * The card stores these DOs and enforces their read/write access rules only.
+ * PIN-only mode and PUK blocking are host decisions. Management-key bytes and
+ * PUK retry counters are changed only by their normal PIV commands; the
+ * firmware does not infer either from ADMIN DATA/PRINTED contents.
  */
 #define PIV_DO_TAG_DISCOVERY 0x0000007Eu
 #define PIV_DO_TAG_BITGT 0x00007F61u
@@ -102,8 +108,8 @@ static enum PIV_STATE piv_state = PIV_STATE_OTHER;
 #define PIV_DO_INLINE_PRINTED_MAX 64
 #define PIV_DO_INLINE_ADMIN_DATA_MAX 128
 
-_Static_assert(sizeof(key_meta_t) + 1u + PIV_DO_INLINE_PRINTED_MAX + PIV_DO_INLINE_ADMIN_DATA_MAX <= 256,
-               "piv-admk attrs must fit in the reserved half of a 512-byte metadata block");
+_Static_assert(PIV_DO_INLINE_PRINTED_MAX + PIV_DO_INLINE_ADMIN_DATA_MAX <= 256,
+               "piv-do attrs must fit in the reserved half of a 512-byte metadata block");
 
 #define PIV_DO_F_GET_PIN 0x01
 #define PIV_DO_F_PUT_ADMIN 0x02
@@ -204,7 +210,6 @@ static const uint8_t pix[] = {0x00, 0x00, 0x10, 0x00, 0x01, 0x00};
 static const uint8_t pin_policy[] = {0x40, 0x10};
 static uint8_t auth_ctx[LENGTH_AUTH_STATE];
 static uint8_t in_admin_status;
-static uint8_t in_pin_protected_admin_status;
 static uint8_t pin_is_consumed;
 static char piv_do_path[MAX_DO_PATH_LEN]; // data object file path during chaining read/write
 static int piv_do_write;                  // -1: not in chaining write, otherwise: count of remaining bytes
@@ -221,9 +226,6 @@ static uint32_t last_touch = UINT32_MAX;
 static piv_algorithm_extension_config_t alg_ext_cfg;
 static uint8_t piv_pke_owned;
 static uint8_t piv_pke_use;
-// Session-local ADMIN DATA bit1 cache. Cleared on SELECT/poweroff and whenever
-// ADMIN DATA or PRINTED changes, because those objects define PIN-only state.
-static uint8_t piv_pin_protected_cache;
 #define piv_crypto_buffer applet_session_scratch.buffer
 
 enum {
@@ -231,12 +233,6 @@ enum {
   PIV_PKE_USE_IMPORT,
   PIV_PKE_USE_AUTH,
   PIV_PKE_USE_RESPONSE,
-};
-
-enum {
-  PIV_PIN_PROTECTED_CACHE_UNKNOWN,
-  PIV_PIN_PROTECTED_CACHE_NO,
-  PIV_PIN_PROTECTED_CACHE_YES,
 };
 
 static pin_t pin = {.min_length = 8, .max_length = 8, .is_validated = 0, .path = "piv-pin"};
@@ -333,8 +329,6 @@ static uint16_t piv_do_inline_capacity(const piv_do_desc_t *desc) {
   }
 }
 
-static void piv_pin_protected_cache_clear(void) { piv_pin_protected_cache = PIV_PIN_PROTECTED_CACHE_UNKNOWN; }
-
 static int piv_parse_data_object_tag(const CAPDU *capdu, uint32_t *tag, uint16_t *header_len) {
   if (LC < 2) return SW_WRONG_LENGTH;
   if (DATA[0] != 0x5C) return SW_WRONG_DATA;
@@ -350,40 +344,17 @@ static int piv_parse_data_object_tag(const CAPDU *capdu, uint32_t *tag, uint16_t
   return SW_NO_ERROR;
 }
 
-static int piv_tlv_len_buf(const uint8_t *buf, uint16_t total_len, uint16_t *off, uint16_t *out) {
-  if (*off >= total_len) return -1;
-  uint8_t b = buf[(*off)++];
-  if ((b & 0x80u) == 0) {
-    *out = b;
-    return 0;
-  }
-
-  const uint8_t len_size = b & 0x7Fu;
-  if (len_size == 0 || len_size > 2 || (uint16_t)(*off + len_size) > total_len) return -1;
-  uint16_t len = 0;
-  for (uint8_t i = 0; i < len_size; ++i) {
-    len = (uint16_t)((len << 8u) | buf[(*off)++]);
-  }
-  *out = len;
-  return 0;
-}
-
-static int piv_do_read_bytes(uint32_t tag, uint8_t *buf, uint16_t cap) {
-  const piv_do_desc_t *desc = piv_find_do(tag);
-  if (desc == NULL || (desc->flags & PIV_DO_F_SYNTH) != 0) return LFS_ERR_NOENT;
-
-  if ((desc->flags & PIV_DO_F_INLINE) != 0) {
-    const int attr_len = read_attr(CARD_ADMIN_KEY_PATH, desc->attr, buf, cap);
-    if (attr_len >= 0) return attr_len;
-  }
-
-  char path[MAX_DO_PATH_LEN];
-  if (!piv_do_get_path(desc, tag, path)) return LFS_ERR_NOENT;
-  return read_file(path, buf, 0, cap);
-}
+static int piv_clear_attr_if_present(const char *path, uint8_t attr);
+static int piv_remove_do_meta_if_empty(void);
 
 static int piv_do_write_inline(const piv_do_desc_t *desc, const uint8_t *data, uint16_t len) {
-  if (write_attr(CARD_ADMIN_KEY_PATH, desc->attr, data, len) < 0) return -1;
+  if (len == 0) {
+    if (piv_clear_attr_if_present(PIV_DO_META_PATH, desc->attr) < 0) return -1;
+    if (piv_remove_do_meta_if_empty() < 0) return -1;
+  } else {
+    if (write_file(PIV_DO_META_PATH, NULL, 0, 0, 0) < 0) return -1;
+    if (write_attr(PIV_DO_META_PATH, desc->attr, data, len) < 0) return -1;
+  }
   if (desc->path != NULL) {
     const int remove_rc = remove_file(desc->path);
     if (remove_rc < 0 && remove_rc != LFS_ERR_NOENT) return -1;
@@ -394,6 +365,27 @@ static int piv_do_write_inline(const piv_do_desc_t *desc, const uint8_t *data, u
 static int piv_remove_file_if_present(const char *path) {
   const int rc = remove_file(path);
   return (rc == 0 || rc == LFS_ERR_NOENT) ? 0 : -1;
+}
+
+static int piv_clear_attr_if_present(const char *path, uint8_t attr) {
+  const int rc = remove_attr(path, attr);
+  return (rc == 0 || rc == LFS_ERR_NOENT || rc == LFS_ERR_NOATTR) ? 0 : -1;
+}
+
+static int piv_attr_present(const char *path, uint8_t attr) {
+  uint8_t probe;
+  const int rc = read_attr(path, attr, &probe, 0);
+  if (rc >= 0) return 1;
+  if (rc == LFS_ERR_NOENT || rc == LFS_ERR_NOATTR) return 0;
+  return -1;
+}
+
+static int piv_remove_do_meta_if_empty(void) {
+  const int printed = piv_attr_present(PIV_DO_META_PATH, PIV_DO_ATTR_PRINTED);
+  if (printed != 0) return printed < 0 ? -1 : 0;
+  const int admin_data = piv_attr_present(PIV_DO_META_PATH, PIV_DO_ATTR_ADMIN_DATA);
+  if (admin_data != 0) return admin_data < 0 ? -1 : 0;
+  return piv_remove_file_if_present(PIV_DO_META_PATH);
 }
 
 static int piv_clear_file_do_storage(void) {
@@ -417,152 +409,10 @@ static int piv_clear_inline_do_storage(void) {
       PIV_DO_ATTR_KEY_HISTORY,
   };
   for (size_t i = 0; i < sizeof(attrs) / sizeof(attrs[0]); ++i) {
-    if (write_attr(CARD_ADMIN_KEY_PATH, attrs[i], NULL, 0) < 0) return -1;
+    if (piv_clear_attr_if_present(PIV_DO_META_PATH, attrs[i]) < 0) return -1;
+    if (piv_clear_attr_if_present(CARD_ADMIN_KEY_PATH, attrs[i]) < 0) return -1;
   }
-  return 0;
-}
-
-static int piv_admin_data_is_pin_protected(const uint8_t *data, uint16_t data_len) {
-  /*
-   * PIN-only ADMIN DATA uses:
-   *   53 len 80 len ... 81 01 <bits> ...
-   * bit0 means PUK blocked; bit1 means the management key is PIN-protected.
-   * Older callers may pass the inner 80 template directly, so the outer 53 is
-   * accepted but not required.
-   */
-  if (data_len == 0) return 0;
-
-  uint16_t off = 0;
-  uint16_t end = data_len;
-  if (data[off] == 0x53) {
-    ++off;
-    uint16_t wrapped_len;
-    if (piv_tlv_len_buf(data, data_len, &off, &wrapped_len) < 0 || (uint16_t)(off + wrapped_len) != data_len) return 0;
-    end = off + wrapped_len;
-  }
-
-  if (off >= end || data[off++] != 0x80) return 0;
-  uint16_t admin_len;
-  if (piv_tlv_len_buf(data, end, &off, &admin_len) < 0 || (uint16_t)(off + admin_len) != end) return 0;
-
-  while (off < end) {
-    const uint8_t tag = data[off++];
-    uint16_t len;
-    if (piv_tlv_len_buf(data, end, &off, &len) < 0 || (uint16_t)(off + len) > end) return 0;
-    if (tag == 0x81) return len == 1 && (data[off] & 0x02u) != 0;
-    off += len;
-  }
-
-  return 0;
-}
-
-static int piv_pin_protected_configured(void) {
-  if (piv_pin_protected_cache == PIV_PIN_PROTECTED_CACHE_YES) return 1;
-  if (piv_pin_protected_cache == PIV_PIN_PROTECTED_CACHE_NO) return 0;
-
-  uint8_t admin_data[PIV_DO_INLINE_ADMIN_DATA_MAX];
-  const int len = piv_do_read_bytes(PIV_DO_TAG_FF(0x00), admin_data, sizeof(admin_data));
-  const int configured = len > 0 && piv_admin_data_is_pin_protected(admin_data, (uint16_t)len);
-  piv_pin_protected_cache = configured ? PIV_PIN_PROTECTED_CACHE_YES : PIV_PIN_PROTECTED_CACHE_NO;
-  return configured;
-}
-
-static int piv_pin_protected_management_key(const uint8_t *data, uint16_t data_len, uint8_t *key, uint16_t *key_len) {
-  /*
-   * PRINTED PIN-protected data is:
-   *   53 len 88 len 89 len <management key>
-   * This implementation only authenticates the current 24-byte TDEA management
-   * key, but the parser accepts 16/24/32-byte key blobs so unsupported AES
-   * PRINTED data is recognized as well-formed and then rejected by policy.
-   */
-  *key_len = 0;
-  if (data_len == 0) return 0;
-
-  uint16_t off = 0;
-  if (data[off++] != 0x53) return -1;
-  uint16_t outer_len;
-  if (piv_tlv_len_buf(data, data_len, &off, &outer_len) < 0 || (uint16_t)(off + outer_len) != data_len) return -1;
-  if (outer_len == 0) return 0;
-  if (off >= data_len || data[off++] != 0x88) return -1;
-  uint16_t protected_len;
-  if (piv_tlv_len_buf(data, data_len, &off, &protected_len) < 0 || (uint16_t)(off + protected_len) != data_len)
-    return -1;
-  if (protected_len == 0) return 0;
-  if (off >= data_len || data[off++] != 0x89) return -1;
-  uint16_t parsed_key_len;
-  if (piv_tlv_len_buf(data, data_len, &off, &parsed_key_len) < 0 || (uint16_t)(off + parsed_key_len) != data_len)
-    return -1;
-  if (parsed_key_len != 16 && parsed_key_len != 24 && parsed_key_len != 32) return -1;
-  memcpy(key, data + off, parsed_key_len);
-  *key_len = parsed_key_len;
-  return 0;
-}
-
-static int piv_write_pin_protected_management_key(const uint8_t *key, uint16_t key_len) {
-  if (key_len != 24) return -1;
-  uint8_t encoded[30];
-  encoded[0] = 0x53;
-  encoded[1] = 0x1C;
-  encoded[2] = 0x88;
-  encoded[3] = 0x1A;
-  encoded[4] = 0x89;
-  encoded[5] = 0x18;
-  memcpy(encoded + 6, key, key_len);
-
-  const piv_do_desc_t *printed = piv_find_do(PIV_DO_TAG_C1(0x09));
-  if (printed == NULL) return -1;
-  return piv_do_write_inline(printed, encoded, sizeof(encoded));
-}
-
-static int piv_admin_status_satisfied(void) {
-  /*
-   * Standard admin authentication sets in_admin_status through GENERAL
-   * AUTHENTICATE. In PIN-protected mode, a currently verified PIN can also
-   * satisfy admin status if ADMIN DATA says bit1 is set and PRINTED contains a
-   * management key equal to the current 9B key. Keep that PIN-derived status in
-   * a separate latch so VERIFY logout can revoke it without clearing a real
-   * management-key authentication.
-   *
-   * Read only the key metadata and the first 24 key bytes here. ck_key_t is
-   * RSA-sized, so reading it just to compare a TDEA key would waste more than
-   * 1 KB of stack and flash I/O on a hot authorization path.
-   */
-  if (in_admin_status) return 1;
-  if (in_pin_protected_admin_status) {
-    if (pin.is_validated) return 1;
-    in_pin_protected_admin_status = 0;
-  }
-  if (!pin.is_validated || !piv_pin_protected_configured()) return 0;
-
-  uint8_t printed[PIV_DO_INLINE_PRINTED_MAX];
-  const int printed_len = piv_do_read_bytes(PIV_DO_TAG_C1(0x09), printed, sizeof(printed));
-  if (printed_len <= 0) return 0;
-
-  uint8_t protected_key[32];
-  uint16_t protected_key_len = 0;
-  const int parsed_key =
-      piv_pin_protected_management_key(printed, (uint16_t)printed_len, protected_key, &protected_key_len);
-  memzero(printed, sizeof(printed));
-  if (parsed_key < 0 || protected_key_len != 24) {
-    memzero(protected_key, sizeof(protected_key));
-    return 0;
-  }
-
-  key_meta_t key_meta;
-  uint8_t admin_key[24];
-  if (ck_read_key_metadata(CARD_ADMIN_KEY_PATH, &key_meta) < 0 ||
-      read_file(CARD_ADMIN_KEY_PATH, admin_key, 0, sizeof(admin_key)) != (int)sizeof(admin_key)) {
-    memzero(admin_key, sizeof(admin_key));
-    memzero(protected_key, sizeof(protected_key));
-    return 0;
-  }
-  const int ok = key_meta.type == TDEA && memcmp_s(admin_key, protected_key, protected_key_len) == 0;
-  memzero(admin_key, sizeof(admin_key));
-  memzero(protected_key, sizeof(protected_key));
-  if (!ok) return 0;
-
-  in_pin_protected_admin_status = 1;
-  return 1;
+  return piv_remove_file_if_present(PIV_DO_META_PATH);
 }
 
 static key_type_t algo_id_to_key_type(const uint8_t id) {
@@ -876,9 +726,7 @@ static void piv_auth_reset(void) {
 void piv_poweroff(void) {
   piv_state = PIV_STATE_OTHER;
   in_admin_status = 0;
-  in_pin_protected_admin_status = 0;
   pin_is_consumed = 0;
-  piv_pin_protected_cache_clear();
   pin.is_validated = 0;
   puk.is_validated = 0;
   piv_do_write = -1;
@@ -966,9 +814,7 @@ static int piv_select(const CAPDU *capdu, RAPDU *rapdu) {
 
   // reset internal states
   in_admin_status = 0;
-  in_pin_protected_admin_status = 0;
   pin_is_consumed = 0;
-  piv_pin_protected_cache_clear();
   pin.is_validated = 0;
   puk.is_validated = 0;
   piv_do_write = -1;
@@ -1055,7 +901,7 @@ static int piv_get_data(const CAPDU *capdu, RAPDU *rapdu) {
   }
 
   if ((desc->flags & PIV_DO_F_INLINE) != 0) {
-    const int attr_len = read_attr(CARD_ADMIN_KEY_PATH, desc->attr, RDATA, desc->capacity);
+    const int attr_len = read_attr(PIV_DO_META_PATH, desc->attr, RDATA, desc->capacity);
     if (attr_len > 0) {
       LL = attr_len;
       return 0;
@@ -1103,7 +949,6 @@ static int piv_verify(const CAPDU *capdu, RAPDU *rapdu) {
     if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
     pin.is_validated = 0;
     pin_is_consumed = 0;
-    in_pin_protected_admin_status = 0;
     return 0;
   }
   if (LC == 0) {
@@ -1315,7 +1160,6 @@ static int piv_general_authenticate_dispatch(const CAPDU *capdu, RAPDU *rapdu, u
     DBG_MSG("Case 2\n");
     authenticate_reset();
     in_admin_status = 0;
-    in_pin_protected_admin_status = 0;
 
     if (P2 != 0x9B) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 
@@ -1365,7 +1209,6 @@ static int piv_general_authenticate_dispatch(const CAPDU *capdu, RAPDU *rapdu, u
     DBG_MSG("Case 4\n");
     authenticate_reset();
     in_admin_status = 0;
-    in_pin_protected_admin_status = 0;
 
     if (P2 != 0x9B) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 
@@ -1502,7 +1345,7 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
 
   if (P1 != 0x3F || P2 != 0xFF) EXCEPT(SW_WRONG_P1P2);
@@ -1523,14 +1366,13 @@ static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
 
     /*
      * Inline-capable DOs use attr storage only below their metadata-safe
-     * ceiling. PRINTED can legally be up to 245 bytes, but only the 30-byte
-     * PIN-protected form should live beside the admin key metadata; larger
-     * PRINTED data is stored as a file after deleting any stale attr copy.
+     * ceiling. PRINTED can legally be up to 245 bytes, but host-managed
+     * management-key references are normally small; larger PRINTED data is
+     * stored as a file after deleting any stale attr copy.
      */
     if ((desc->flags & PIV_DO_F_INLINE) != 0 && size <= piv_do_inline_capacity(desc)) {
       if ((CLA & 0x10) != 0) EXCEPT(SW_WRONG_LENGTH);
       if (piv_do_write_inline(desc, payload, size) < 0) return -1;
-      if (tag == PIV_DO_TAG_FF(0x00) || tag == PIV_DO_TAG_C1(0x09)) piv_pin_protected_cache_clear();
       return 0;
     }
 
@@ -1538,13 +1380,10 @@ static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
       EXCEPT(SW_WRONG_LENGTH);
     }
 
-    if ((desc->flags & PIV_DO_F_INLINE) != 0 && write_attr(CARD_ADMIN_KEY_PATH, desc->attr, NULL, 0) < 0) {
+    if ((desc->flags & PIV_DO_F_INLINE) != 0 && piv_clear_attr_if_present(PIV_DO_META_PATH, desc->attr) < 0) {
       return -1;
     }
-
-    if (tag == PIV_DO_TAG_FF(0x00) || tag == PIV_DO_TAG_C1(0x09)) {
-      piv_pin_protected_cache_clear();
-    }
+    if ((desc->flags & PIV_DO_F_INLINE) != 0 && piv_remove_do_meta_if_empty() < 0) return -1;
 
     char path[MAX_DO_PATH_LEN];
     if (!piv_do_get_path(desc, tag, path)) EXCEPT(SW_FILE_NOT_FOUND);
@@ -1587,7 +1426,7 @@ static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_generate_asymmetric_key_pair(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
   if (LC < 5) {
     DBG_MSG("Wrong length\n");
@@ -1638,12 +1477,11 @@ static int piv_set_management_key(const CAPDU *capdu, RAPDU *rapdu) {
   if (LC != 27) EXCEPT(SW_WRONG_LENGTH);
   if (DATA[0] != 0x03 || DATA[1] != 0x9B || DATA[2] != 24) EXCEPT(SW_WRONG_DATA);
 #ifndef FUZZ
-  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
   if (write_file(CARD_ADMIN_KEY_PATH, DATA + 3, 0, 24, 1) < 0) return -1;
   const uint8_t is_default = !memcmp(DATA + 3, DEFAULT_MGMT_KEY, 24);
   if (write_attr(CARD_ADMIN_KEY_PATH, TAG_PIN_KEY_DEFAULT, &is_default, sizeof(is_default)) < 0) return -1;
-  if (piv_pin_protected_configured() && piv_write_pin_protected_management_key(DATA + 3, 24) < 0) return -1;
   return 0;
 }
 
@@ -1657,7 +1495,7 @@ static int piv_reset(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_import_asymmetric_key(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
   const char *key_path = get_key_path(P2);
   if (key_path == NULL || P2 == 0x9B) {
@@ -1860,7 +1698,7 @@ static int piv_get_serial(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_algorithm_extension(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
 
   if (P1 != 0x01 && P1 != 0x02) EXCEPT(SW_WRONG_P1P2);

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -103,7 +103,7 @@ static enum PIV_STATE piv_state = PIV_STATE_OTHER;
 #define PIV_DO_INLINE_ADMIN_DATA_MAX 128
 
 _Static_assert(sizeof(key_meta_t) + 1u + PIV_DO_INLINE_PRINTED_MAX + PIV_DO_INLINE_ADMIN_DATA_MAX <= 256,
-               "piv-admk attrs must leave room in a 512-byte metadata block");
+               "piv-admk attrs must fit in the reserved half of a 512-byte metadata block");
 
 #define PIV_DO_F_GET_PIN 0x01
 #define PIV_DO_F_PUT_ADMIN 0x02
@@ -204,6 +204,7 @@ static const uint8_t pix[] = {0x00, 0x00, 0x10, 0x00, 0x01, 0x00};
 static const uint8_t pin_policy[] = {0x40, 0x10};
 static uint8_t auth_ctx[LENGTH_AUTH_STATE];
 static uint8_t in_admin_status;
+static uint8_t in_pin_protected_admin_status;
 static uint8_t pin_is_consumed;
 static char piv_do_path[MAX_DO_PATH_LEN]; // data object file path during chaining read/write
 static int piv_do_write;                  // -1: not in chaining write, otherwise: count of remaining bytes
@@ -516,15 +517,21 @@ static int piv_write_pin_protected_management_key(const uint8_t *key, uint16_t k
 static int piv_admin_status_satisfied(void) {
   /*
    * Standard admin authentication sets in_admin_status through GENERAL
-   * AUTHENTICATE. In PIN-protected mode, a verified PIN can also satisfy admin
-   * status if ADMIN DATA says bit1 is set and PRINTED contains a management key
-   * equal to the current 9B key.
+   * AUTHENTICATE. In PIN-protected mode, a currently verified PIN can also
+   * satisfy admin status if ADMIN DATA says bit1 is set and PRINTED contains a
+   * management key equal to the current 9B key. Keep that PIN-derived status in
+   * a separate latch so VERIFY logout can revoke it without clearing a real
+   * management-key authentication.
    *
    * Read only the key metadata and the first 24 key bytes here. ck_key_t is
    * RSA-sized, so reading it just to compare a TDEA key would waste more than
    * 1 KB of stack and flash I/O on a hot authorization path.
    */
   if (in_admin_status) return 1;
+  if (in_pin_protected_admin_status) {
+    if (pin.is_validated) return 1;
+    in_pin_protected_admin_status = 0;
+  }
   if (!pin.is_validated || !piv_pin_protected_configured()) return 0;
 
   uint8_t printed[PIV_DO_INLINE_PRINTED_MAX];
@@ -554,7 +561,7 @@ static int piv_admin_status_satisfied(void) {
   memzero(protected_key, sizeof(protected_key));
   if (!ok) return 0;
 
-  in_admin_status = 1;
+  in_pin_protected_admin_status = 1;
   return 1;
 }
 
@@ -869,6 +876,7 @@ static void piv_auth_reset(void) {
 void piv_poweroff(void) {
   piv_state = PIV_STATE_OTHER;
   in_admin_status = 0;
+  in_pin_protected_admin_status = 0;
   pin_is_consumed = 0;
   piv_pin_protected_cache_clear();
   pin.is_validated = 0;
@@ -958,6 +966,7 @@ static int piv_select(const CAPDU *capdu, RAPDU *rapdu) {
 
   // reset internal states
   in_admin_status = 0;
+  in_pin_protected_admin_status = 0;
   pin_is_consumed = 0;
   piv_pin_protected_cache_clear();
   pin.is_validated = 0;
@@ -1060,8 +1069,6 @@ static int piv_get_data(const CAPDU *capdu, RAPDU *rapdu) {
   if (size == LFS_ERR_NOENT || size == 0) EXCEPT(SW_FILE_NOT_FOUND);
   if (size < 0) return -1;
   return piv_get_large_data(capdu, rapdu, path, size);
-
-  return 0;
 }
 
 static int piv_get_data_response(const CAPDU *capdu, RAPDU *rapdu) {
@@ -1096,6 +1103,7 @@ static int piv_verify(const CAPDU *capdu, RAPDU *rapdu) {
     if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
     pin.is_validated = 0;
     pin_is_consumed = 0;
+    in_pin_protected_admin_status = 0;
     return 0;
   }
   if (LC == 0) {
@@ -1307,6 +1315,7 @@ static int piv_general_authenticate_dispatch(const CAPDU *capdu, RAPDU *rapdu, u
     DBG_MSG("Case 2\n");
     authenticate_reset();
     in_admin_status = 0;
+    in_pin_protected_admin_status = 0;
 
     if (P2 != 0x9B) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 
@@ -1356,6 +1365,7 @@ static int piv_general_authenticate_dispatch(const CAPDU *capdu, RAPDU *rapdu, u
     DBG_MSG("Case 4\n");
     authenticate_reset();
     in_admin_status = 0;
+    in_pin_protected_admin_status = 0;
 
     if (P2 != 0x9B) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -70,8 +70,29 @@ enum PIV_STATE {
 static enum PIV_STATE piv_state = PIV_STATE_OTHER;
 // clang-format on
 
-// PIV data object registry. Keep the APDU-facing object metadata in ROM and
-// create LittleFS files only when an object is actually written.
+/*
+ * PIV data object storage model
+ *
+ * Keep APDU-facing DO metadata in this ROM table, not as pre-created LittleFS
+ * files. Optional objects are created lazily on PUT DATA, so unsupported or
+ * empty cert/biometric/retired-cert objects do not burn a 512-byte LittleFS
+ * metadata block each.
+ *
+ * LittleFS metadata blocks are 512 bytes on the target. Do not aggregate
+ * several large DO attrs on a single file: attr payloads plus LittleFS metadata
+ * tags must fit in that one block. Only the PIN-only objects that are small in
+ * normal PIN-only-compatible use live on CARD_ADMIN_KEY_PATH attrs:
+ *
+ *   - ADMIN DATA, max 128 bytes.
+ *   - PRINTED, only while it is <= 64 bytes. The PIN-protected encoding is
+ *     30 bytes: 53 1c 88 1a 89 18 <24-byte management key>.
+ *
+ * The static assert below intentionally caps those attr payloads to half a
+ * metadata block, leaving room for key metadata, the default-key attr, LittleFS
+ * tag overhead, and future small attrs. Larger PRINTED payloads fall back to
+ * PI_PATH. SECURITY and KEY HISTORY are file-backed so they cannot crowd the
+ * admin-key metadata block.
+ */
 #define PIV_DO_TAG_DISCOVERY 0x0000007Eu
 #define PIV_DO_TAG_BITGT 0x00007F61u
 #define PIV_DO_TAG_C1(x) (0x005FC100u | (uint32_t)(x))
@@ -93,15 +114,16 @@ _Static_assert(sizeof(key_meta_t) + 1u + PIV_DO_INLINE_PRINTED_MAX + PIV_DO_INLI
 
 #define PIV_DO_ATTR_PRINTED 0x90
 #define PIV_DO_ATTR_ADMIN_DATA 0x91
+// Kept only so reset can delete stale attrs written by older layouts.
 #define PIV_DO_ATTR_SECURITY 0x92
 #define PIV_DO_ATTR_KEY_HISTORY 0x93
 
 typedef struct {
-  uint32_t tag;
-  const char *path;
-  uint16_t capacity;
-  uint8_t flags;
-  uint8_t attr;
+  uint32_t tag;      // APDU DO tag as parsed from 5C.
+  const char *path;  // NULL for synthesized or attr-only objects.
+  uint16_t capacity; // Maximum stored payload size, not including the 5C tag-list header.
+  uint8_t flags;     // Access/storage flags.
+  uint8_t attr;      // LittleFS attr id when PIV_DO_F_INLINE is set.
 } piv_do_desc_t;
 
 // tags for general auth
@@ -198,6 +220,8 @@ static uint32_t last_touch = UINT32_MAX;
 static piv_algorithm_extension_config_t alg_ext_cfg;
 static uint8_t piv_pke_owned;
 static uint8_t piv_pke_use;
+// Session-local ADMIN DATA bit1 cache. Cleared on SELECT/poweroff and whenever
+// ADMIN DATA or PRINTED changes, because those objects define PIN-only state.
 static uint8_t piv_pin_protected_cache;
 #define piv_crypto_buffer applet_session_scratch.buffer
 
@@ -256,6 +280,9 @@ static const piv_do_desc_t piv_do_table[] = {
 
 static const piv_do_desc_t piv_do_retired_cert_desc = {0, NULL, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0};
 
+// Retired key-management certs follow the contiguous NIST tag range
+// 5FC10D..5FC120. The first two keep their historical paths; the rest use a
+// generated short path piv-rXX to avoid 18 extra table entries.
 static int piv_is_retired_cert_tag(uint32_t tag) { return tag >= PIV_DO_TAG_C1(0x0F) && tag <= PIV_DO_TAG_C1(0x20); }
 
 static char piv_hex_nibble(uint8_t x) { return x < 10 ? (char)('0' + x) : (char)('a' + x - 10); }
@@ -292,6 +319,8 @@ static int piv_do_get_path(const piv_do_desc_t *desc, uint32_t tag, char path[MA
   return 0;
 }
 
+// Returns the attr storage ceiling for DOs that are allowed to inline. A zero
+// return means the object is file-backed even if it has a historical stale attr.
 static uint16_t piv_do_inline_capacity(const piv_do_desc_t *desc) {
   switch (desc->attr) {
   case PIV_DO_ATTR_PRINTED:
@@ -393,6 +422,13 @@ static int piv_clear_inline_do_storage(void) {
 }
 
 static int piv_admin_data_is_pin_protected(const uint8_t *data, uint16_t data_len) {
+  /*
+   * PIN-only ADMIN DATA uses:
+   *   53 len 80 len ... 81 01 <bits> ...
+   * bit0 means PUK blocked; bit1 means the management key is PIN-protected.
+   * Older callers may pass the inner 80 template directly, so the outer 53 is
+   * accepted but not required.
+   */
   if (data_len == 0) return 0;
 
   uint16_t off = 0;
@@ -431,6 +467,13 @@ static int piv_pin_protected_configured(void) {
 }
 
 static int piv_pin_protected_management_key(const uint8_t *data, uint16_t data_len, uint8_t *key, uint16_t *key_len) {
+  /*
+   * PRINTED PIN-protected data is:
+   *   53 len 88 len 89 len <management key>
+   * This implementation only authenticates the current 24-byte TDEA management
+   * key, but the parser accepts 16/24/32-byte key blobs so unsupported AES
+   * PRINTED data is recognized as well-formed and then rejected by policy.
+   */
   *key_len = 0;
   if (data_len == 0) return 0;
 
@@ -471,6 +514,16 @@ static int piv_write_pin_protected_management_key(const uint8_t *key, uint16_t k
 }
 
 static int piv_admin_status_satisfied(void) {
+  /*
+   * Standard admin authentication sets in_admin_status through GENERAL
+   * AUTHENTICATE. In PIN-protected mode, a verified PIN can also satisfy admin
+   * status if ADMIN DATA says bit1 is set and PRINTED contains a management key
+   * equal to the current 9B key.
+   *
+   * Read only the key metadata and the first 24 key bytes here. ck_key_t is
+   * RSA-sized, so reading it just to compare a TDEA key would waste more than
+   * 1 KB of stack and flash I/O on a hot authorization path.
+   */
   if (in_admin_status) return 1;
   if (!pin.is_validated || !piv_pin_protected_configured()) return 0;
 
@@ -1458,6 +1511,12 @@ static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
     if (size > desc->capacity) EXCEPT(SW_WRONG_LENGTH);
     const uint8_t *payload = DATA + header_len;
 
+    /*
+     * Inline-capable DOs use attr storage only below their metadata-safe
+     * ceiling. PRINTED can legally be up to 245 bytes, but only the 30-byte
+     * PIN-protected form should live beside the admin key metadata; larger
+     * PRINTED data is stored as a file after deleting any stale attr copy.
+     */
     if ((desc->flags & PIV_DO_F_INLINE) != 0 && size <= piv_do_inline_capacity(desc)) {
       if ((CLA & 0x10) != 0) EXCEPT(SW_WRONG_LENGTH);
       if (piv_do_write_inline(desc, payload, size) < 0) return -1;

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -28,6 +28,9 @@
 #define PI_PATH                     "piv-pi"   // printed information
 #define FINGER_PATH                 "piv-fig"  // card holder fingerprints
 #define FACE_PATH                   "piv-face" // card holder facial image
+#define SECURITY_PATH               "piv-sec"  // security object
+#define KEY_HISTORY_PATH            "piv-kh"   // key history object
+#define IRIS_PATH                   "piv-iris" // card holder iris images
 // clang-format on
 
 // key tags and path
@@ -66,6 +69,40 @@ enum PIV_STATE {
 };
 static enum PIV_STATE piv_state = PIV_STATE_OTHER;
 // clang-format on
+
+// PIV data object registry. Keep the APDU-facing object metadata in ROM and
+// create LittleFS files only when an object is actually written.
+#define PIV_DO_TAG_DISCOVERY 0x0000007Eu
+#define PIV_DO_TAG_BITGT 0x00007F61u
+#define PIV_DO_TAG_C1(x) (0x005FC100u | (uint32_t)(x))
+#define PIV_DO_TAG_FF(x) (0x005FFF00u | (uint32_t)(x))
+
+#define PIV_DO_PRINTED_CAPACITY 245
+#define PIV_DO_INLINE_PRINTED_MAX 64
+#define PIV_DO_INLINE_ADMIN_DATA_MAX 128
+
+_Static_assert(sizeof(key_meta_t) + 1u + PIV_DO_INLINE_PRINTED_MAX + PIV_DO_INLINE_ADMIN_DATA_MAX <= 256,
+               "piv-admk attrs must leave room in a 512-byte metadata block");
+
+#define PIV_DO_F_GET_PIN 0x01
+#define PIV_DO_F_PUT_ADMIN 0x02
+#define PIV_DO_F_CERT 0x04
+#define PIV_DO_F_READ_ONLY 0x08
+#define PIV_DO_F_SYNTH 0x10
+#define PIV_DO_F_INLINE 0x20
+
+#define PIV_DO_ATTR_PRINTED 0x90
+#define PIV_DO_ATTR_ADMIN_DATA 0x91
+#define PIV_DO_ATTR_SECURITY 0x92
+#define PIV_DO_ATTR_KEY_HISTORY 0x93
+
+typedef struct {
+  uint32_t tag;
+  const char *path;
+  uint16_t capacity;
+  uint8_t flags;
+  uint8_t attr;
+} piv_do_desc_t;
 
 // tags for general auth
 // clang-format off
@@ -161,6 +198,7 @@ static uint32_t last_touch = UINT32_MAX;
 static piv_algorithm_extension_config_t alg_ext_cfg;
 static uint8_t piv_pke_owned;
 static uint8_t piv_pke_use;
+static uint8_t piv_pin_protected_cache;
 #define piv_crypto_buffer applet_session_scratch.buffer
 
 enum {
@@ -168,6 +206,12 @@ enum {
   PIV_PKE_USE_IMPORT,
   PIV_PKE_USE_AUTH,
   PIV_PKE_USE_RESPONSE,
+};
+
+enum {
+  PIV_PIN_PROTECTED_CACHE_UNKNOWN,
+  PIV_PIN_PROTECTED_CACHE_NO,
+  PIV_PIN_PROTECTED_CACHE_YES,
 };
 
 static pin_t pin = {.min_length = 8, .max_length = 8, .is_validated = 0, .path = "piv-pin"};
@@ -186,6 +230,279 @@ static int create_key(const char *path, const key_usage_t usage, const pin_polic
                                  .touch_policy = TOUCH_POLICY_NEVER}};
   if (ck_write_key(path, &key) < 0) return -1;
   return 0;
+}
+
+static const piv_do_desc_t piv_do_table[] = {
+    {PIV_DO_TAG_DISCOVERY, NULL, 0, PIV_DO_F_SYNTH | PIV_DO_F_READ_ONLY, 0},
+    {PIV_DO_TAG_BITGT, NULL, 0, PIV_DO_F_READ_ONLY, 0},
+    {PIV_DO_TAG_C1(0x01), CARD_AUTH_CERT_PATH, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0},
+    {PIV_DO_TAG_C1(0x02), CHUID_PATH, 2916, PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_C1(0x03), FINGER_PATH, 512, PIV_DO_F_GET_PIN | PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_C1(0x05), PIV_AUTH_CERT_PATH, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0},
+    {PIV_DO_TAG_C1(0x06), SECURITY_PATH, 245, PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_C1(0x07), CCC_PATH, 287, PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_C1(0x08), FACE_PATH, 512, PIV_DO_F_GET_PIN | PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_C1(0x09), PI_PATH, PIV_DO_PRINTED_CAPACITY, PIV_DO_F_GET_PIN | PIV_DO_F_PUT_ADMIN | PIV_DO_F_INLINE,
+     PIV_DO_ATTR_PRINTED},
+    {PIV_DO_TAG_C1(0x0A), SIG_CERT_PATH, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0},
+    {PIV_DO_TAG_C1(0x0B), KEY_MANAGEMENT_CERT_PATH, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0},
+    {PIV_DO_TAG_C1(0x0C), KEY_HISTORY_PATH, 32, PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_C1(0x0D), KEY_MANAGEMENT_82_CERT_PATH, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0},
+    {PIV_DO_TAG_C1(0x0E), KEY_MANAGEMENT_83_CERT_PATH, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0},
+    {PIV_DO_TAG_C1(0x21), IRIS_PATH, 512, PIV_DO_F_GET_PIN | PIV_DO_F_PUT_ADMIN, 0},
+    {PIV_DO_TAG_FF(0x00), NULL, PIV_DO_INLINE_ADMIN_DATA_MAX, PIV_DO_F_PUT_ADMIN | PIV_DO_F_INLINE,
+     PIV_DO_ATTR_ADMIN_DATA},
+};
+
+static const piv_do_desc_t piv_do_retired_cert_desc = {0, NULL, 3000, PIV_DO_F_PUT_ADMIN | PIV_DO_F_CERT, 0};
+
+static int piv_is_retired_cert_tag(uint32_t tag) { return tag >= PIV_DO_TAG_C1(0x0F) && tag <= PIV_DO_TAG_C1(0x20); }
+
+static char piv_hex_nibble(uint8_t x) { return x < 10 ? (char)('0' + x) : (char)('a' + x - 10); }
+
+static void piv_retired_cert_path(uint32_t tag, char path[MAX_DO_PATH_LEN]) {
+  const uint8_t id = (uint8_t)(tag & 0xFFu);
+  path[0] = 'p';
+  path[1] = 'i';
+  path[2] = 'v';
+  path[3] = '-';
+  path[4] = 'r';
+  path[5] = piv_hex_nibble(id >> 4u);
+  path[6] = piv_hex_nibble(id & 0x0Fu);
+  path[7] = '\0';
+}
+
+static const piv_do_desc_t *piv_find_do(uint32_t tag) {
+  for (size_t i = 0; i < sizeof(piv_do_table) / sizeof(piv_do_table[0]); ++i) {
+    if (piv_do_table[i].tag == tag) return &piv_do_table[i];
+  }
+  return piv_is_retired_cert_tag(tag) ? &piv_do_retired_cert_desc : NULL;
+}
+
+static int piv_do_get_path(const piv_do_desc_t *desc, uint32_t tag, char path[MAX_DO_PATH_LEN]) {
+  if (desc->path != NULL) {
+    strcpy(path, desc->path);
+    return 1;
+  }
+  if (desc == &piv_do_retired_cert_desc) {
+    piv_retired_cert_path(tag, path);
+    return 1;
+  }
+  path[0] = '\0';
+  return 0;
+}
+
+static uint16_t piv_do_inline_capacity(const piv_do_desc_t *desc) {
+  switch (desc->attr) {
+  case PIV_DO_ATTR_PRINTED:
+    return PIV_DO_INLINE_PRINTED_MAX;
+  case PIV_DO_ATTR_ADMIN_DATA:
+    return PIV_DO_INLINE_ADMIN_DATA_MAX;
+  default:
+    return 0;
+  }
+}
+
+static void piv_pin_protected_cache_clear(void) { piv_pin_protected_cache = PIV_PIN_PROTECTED_CACHE_UNKNOWN; }
+
+static int piv_parse_data_object_tag(const CAPDU *capdu, uint32_t *tag, uint16_t *header_len) {
+  if (LC < 2) return SW_WRONG_LENGTH;
+  if (DATA[0] != 0x5C) return SW_WRONG_DATA;
+  const uint8_t tag_len = DATA[1];
+  if (tag_len == 0 || tag_len > 3 || (uint16_t)(2 + tag_len) > LC) return SW_WRONG_LENGTH;
+
+  uint32_t parsed = 0;
+  for (uint8_t i = 0; i < tag_len; ++i) {
+    parsed = (parsed << 8u) | DATA[2 + i];
+  }
+  *tag = parsed;
+  *header_len = 2 + tag_len;
+  return SW_NO_ERROR;
+}
+
+static int piv_tlv_len_buf(const uint8_t *buf, uint16_t total_len, uint16_t *off, uint16_t *out) {
+  if (*off >= total_len) return -1;
+  uint8_t b = buf[(*off)++];
+  if ((b & 0x80u) == 0) {
+    *out = b;
+    return 0;
+  }
+
+  const uint8_t len_size = b & 0x7Fu;
+  if (len_size == 0 || len_size > 2 || (uint16_t)(*off + len_size) > total_len) return -1;
+  uint16_t len = 0;
+  for (uint8_t i = 0; i < len_size; ++i) {
+    len = (uint16_t)((len << 8u) | buf[(*off)++]);
+  }
+  *out = len;
+  return 0;
+}
+
+static int piv_do_read_bytes(uint32_t tag, uint8_t *buf, uint16_t cap) {
+  const piv_do_desc_t *desc = piv_find_do(tag);
+  if (desc == NULL || (desc->flags & PIV_DO_F_SYNTH) != 0) return LFS_ERR_NOENT;
+
+  if ((desc->flags & PIV_DO_F_INLINE) != 0) {
+    const int attr_len = read_attr(CARD_ADMIN_KEY_PATH, desc->attr, buf, cap);
+    if (attr_len >= 0) return attr_len;
+  }
+
+  char path[MAX_DO_PATH_LEN];
+  if (!piv_do_get_path(desc, tag, path)) return LFS_ERR_NOENT;
+  return read_file(path, buf, 0, cap);
+}
+
+static int piv_do_write_inline(const piv_do_desc_t *desc, const uint8_t *data, uint16_t len) {
+  if (write_attr(CARD_ADMIN_KEY_PATH, desc->attr, data, len) < 0) return -1;
+  if (desc->path != NULL) {
+    const int remove_rc = remove_file(desc->path);
+    if (remove_rc < 0 && remove_rc != LFS_ERR_NOENT) return -1;
+  }
+  return 0;
+}
+
+static int piv_remove_file_if_present(const char *path) {
+  const int rc = remove_file(path);
+  return (rc == 0 || rc == LFS_ERR_NOENT) ? 0 : -1;
+}
+
+static int piv_clear_file_do_storage(void) {
+  for (size_t i = 0; i < sizeof(piv_do_table) / sizeof(piv_do_table[0]); ++i) {
+    if (piv_do_table[i].path != NULL && piv_remove_file_if_present(piv_do_table[i].path) < 0) return -1;
+  }
+
+  char path[MAX_DO_PATH_LEN];
+  for (uint32_t tag = PIV_DO_TAG_C1(0x0F); tag <= PIV_DO_TAG_C1(0x20); ++tag) {
+    piv_retired_cert_path(tag, path);
+    if (piv_remove_file_if_present(path) < 0) return -1;
+  }
+  return 0;
+}
+
+static int piv_clear_inline_do_storage(void) {
+  static const uint8_t attrs[] = {
+      PIV_DO_ATTR_PRINTED,
+      PIV_DO_ATTR_ADMIN_DATA,
+      PIV_DO_ATTR_SECURITY,
+      PIV_DO_ATTR_KEY_HISTORY,
+  };
+  for (size_t i = 0; i < sizeof(attrs) / sizeof(attrs[0]); ++i) {
+    if (write_attr(CARD_ADMIN_KEY_PATH, attrs[i], NULL, 0) < 0) return -1;
+  }
+  return 0;
+}
+
+static int piv_admin_data_is_pin_protected(const uint8_t *data, uint16_t data_len) {
+  if (data_len == 0) return 0;
+
+  uint16_t off = 0;
+  uint16_t end = data_len;
+  if (data[off] == 0x53) {
+    ++off;
+    uint16_t wrapped_len;
+    if (piv_tlv_len_buf(data, data_len, &off, &wrapped_len) < 0 || (uint16_t)(off + wrapped_len) != data_len) return 0;
+    end = off + wrapped_len;
+  }
+
+  if (off >= end || data[off++] != 0x80) return 0;
+  uint16_t admin_len;
+  if (piv_tlv_len_buf(data, end, &off, &admin_len) < 0 || (uint16_t)(off + admin_len) != end) return 0;
+
+  while (off < end) {
+    const uint8_t tag = data[off++];
+    uint16_t len;
+    if (piv_tlv_len_buf(data, end, &off, &len) < 0 || (uint16_t)(off + len) > end) return 0;
+    if (tag == 0x81) return len == 1 && (data[off] & 0x02u) != 0;
+    off += len;
+  }
+
+  return 0;
+}
+
+static int piv_pin_protected_configured(void) {
+  if (piv_pin_protected_cache == PIV_PIN_PROTECTED_CACHE_YES) return 1;
+  if (piv_pin_protected_cache == PIV_PIN_PROTECTED_CACHE_NO) return 0;
+
+  uint8_t admin_data[PIV_DO_INLINE_ADMIN_DATA_MAX];
+  const int len = piv_do_read_bytes(PIV_DO_TAG_FF(0x00), admin_data, sizeof(admin_data));
+  const int configured = len > 0 && piv_admin_data_is_pin_protected(admin_data, (uint16_t)len);
+  piv_pin_protected_cache = configured ? PIV_PIN_PROTECTED_CACHE_YES : PIV_PIN_PROTECTED_CACHE_NO;
+  return configured;
+}
+
+static int piv_pin_protected_management_key(const uint8_t *data, uint16_t data_len, uint8_t *key, uint16_t *key_len) {
+  *key_len = 0;
+  if (data_len == 0) return 0;
+
+  uint16_t off = 0;
+  if (data[off++] != 0x53) return -1;
+  uint16_t outer_len;
+  if (piv_tlv_len_buf(data, data_len, &off, &outer_len) < 0 || (uint16_t)(off + outer_len) != data_len) return -1;
+  if (outer_len == 0) return 0;
+  if (off >= data_len || data[off++] != 0x88) return -1;
+  uint16_t protected_len;
+  if (piv_tlv_len_buf(data, data_len, &off, &protected_len) < 0 || (uint16_t)(off + protected_len) != data_len)
+    return -1;
+  if (protected_len == 0) return 0;
+  if (off >= data_len || data[off++] != 0x89) return -1;
+  uint16_t parsed_key_len;
+  if (piv_tlv_len_buf(data, data_len, &off, &parsed_key_len) < 0 || (uint16_t)(off + parsed_key_len) != data_len)
+    return -1;
+  if (parsed_key_len != 16 && parsed_key_len != 24 && parsed_key_len != 32) return -1;
+  memcpy(key, data + off, parsed_key_len);
+  *key_len = parsed_key_len;
+  return 0;
+}
+
+static int piv_write_pin_protected_management_key(const uint8_t *key, uint16_t key_len) {
+  if (key_len != 24) return -1;
+  uint8_t encoded[30];
+  encoded[0] = 0x53;
+  encoded[1] = 0x1C;
+  encoded[2] = 0x88;
+  encoded[3] = 0x1A;
+  encoded[4] = 0x89;
+  encoded[5] = 0x18;
+  memcpy(encoded + 6, key, key_len);
+
+  const piv_do_desc_t *printed = piv_find_do(PIV_DO_TAG_C1(0x09));
+  if (printed == NULL) return -1;
+  return piv_do_write_inline(printed, encoded, sizeof(encoded));
+}
+
+static int piv_admin_status_satisfied(void) {
+  if (in_admin_status) return 1;
+  if (!pin.is_validated || !piv_pin_protected_configured()) return 0;
+
+  uint8_t printed[PIV_DO_INLINE_PRINTED_MAX];
+  const int printed_len = piv_do_read_bytes(PIV_DO_TAG_C1(0x09), printed, sizeof(printed));
+  if (printed_len <= 0) return 0;
+
+  uint8_t protected_key[32];
+  uint16_t protected_key_len = 0;
+  const int parsed_key =
+      piv_pin_protected_management_key(printed, (uint16_t)printed_len, protected_key, &protected_key_len);
+  memzero(printed, sizeof(printed));
+  if (parsed_key < 0 || protected_key_len != 24) {
+    memzero(protected_key, sizeof(protected_key));
+    return 0;
+  }
+
+  key_meta_t key_meta;
+  uint8_t admin_key[24];
+  if (ck_read_key_metadata(CARD_ADMIN_KEY_PATH, &key_meta) < 0 ||
+      read_file(CARD_ADMIN_KEY_PATH, admin_key, 0, sizeof(admin_key)) != (int)sizeof(admin_key)) {
+    memzero(admin_key, sizeof(admin_key));
+    memzero(protected_key, sizeof(protected_key));
+    return 0;
+  }
+  const int ok = key_meta.type == TDEA && memcmp_s(admin_key, protected_key, protected_key_len) == 0;
+  memzero(admin_key, sizeof(admin_key));
+  memzero(protected_key, sizeof(protected_key));
+  if (!ok) return 0;
+
+  in_admin_status = 1;
+  return 1;
 }
 
 static key_type_t algo_id_to_key_type(const uint8_t id) {
@@ -500,6 +817,7 @@ void piv_poweroff(void) {
   piv_state = PIV_STATE_OTHER;
   in_admin_status = 0;
   pin_is_consumed = 0;
+  piv_pin_protected_cache_clear();
   pin.is_validated = 0;
   puk.is_validated = 0;
   piv_do_write = -1;
@@ -515,18 +833,8 @@ int piv_install(const uint8_t reset) {
     if (read_file(ALGORITHM_EXT_CONFIG_PATH, &alg_ext_cfg, 0, sizeof(alg_ext_cfg)) < 0) return -1;
     return 0;
   }
+  if (reset && piv_clear_file_do_storage() < 0) return -1;
 
-  static const char *const object_paths[] = {
-      PIV_AUTH_CERT_PATH,
-      SIG_CERT_PATH,
-      KEY_MANAGEMENT_CERT_PATH,
-      CARD_AUTH_CERT_PATH,
-      KEY_MANAGEMENT_82_CERT_PATH,
-      KEY_MANAGEMENT_83_CERT_PATH,
-      PI_PATH,
-      FINGER_PATH,
-      FACE_PATH,
-  };
   static const struct {
     const char *path;
     key_usage_t usage;
@@ -540,10 +848,8 @@ int piv_install(const uint8_t reset) {
       {KEY_MANAGEMENT_83_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
   };
 
-  // objects
-  for (size_t i = 0; i < sizeof(object_paths) / sizeof(object_paths[0]); ++i) {
-    if (write_file(object_paths[i], NULL, 0, 0, 1) < 0) return -1;
-  }
+  // Default objects. Optional DO files are created lazily on PUT DATA so empty
+  // retired cert and biometric objects do not consume LittleFS metadata blocks.
   uint8_t ccc_tpl[] = {0x53, 0x33, 0xf0, 0x15, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xf1, 0x01, 0x21,
                        0xf2, 0x01, 0x21, 0xf3, 0x00, 0xf4, 0x01, 0x00, 0xf5, 0x01, 0x10, 0xf6, 0x00, 0xf7,
@@ -570,6 +876,7 @@ int piv_install(const uint8_t reset) {
                                  .touch_policy = TOUCH_POLICY_NEVER}};
   memcpy(admin_key.data, DEFAULT_MGMT_KEY, 24);
   if (ck_write_key(CARD_ADMIN_KEY_PATH, &admin_key) < 0) return -1;
+  if (reset && piv_clear_inline_do_storage() < 0) return -1;
   const uint8_t tmp = 0x01;
   if (write_attr(CARD_ADMIN_KEY_PATH, TAG_PIN_KEY_DEFAULT, &tmp, sizeof(tmp)) < 0) return -1;
 
@@ -593,80 +900,13 @@ int piv_install(const uint8_t reset) {
   return 0;
 }
 
-static const char *get_object_path_by_tag(const uint8_t tag) {
-  // Part 1 Table 3 0x5FC1XX
-  switch (tag) {
-  case 0x05: // X.509 Certificate for PIV Authentication
-    return PIV_AUTH_CERT_PATH;
-  case 0x0A: // X.509 Certificate for Digital Signature
-    return SIG_CERT_PATH;
-  case 0x0B: // X.509 Certificate for Key Management
-    return KEY_MANAGEMENT_CERT_PATH;
-  case 0x01: // X.509 Certificate for Card Authentication
-    return CARD_AUTH_CERT_PATH;
-  case 0x0D: // Retired X.509 Certificate for Key Management 1
-    return KEY_MANAGEMENT_82_CERT_PATH;
-  case 0x0E: // Retired X.509 Certificate for Key Management 2
-    return KEY_MANAGEMENT_83_CERT_PATH;
-  case 0x02: // Card Holder Unique Identifier
-    return CHUID_PATH;
-  case 0x07: // Card Capability Container
-    return CCC_PATH;
-  case 0x09: // Printed Information
-    return PI_PATH;
-  case 0x03: // Fingerprints
-    return FINGER_PATH;
-  case 0x08: // Facial Images
-    return FACE_PATH;
-  default:
-    return NULL;
-  }
-}
-
-static uint16_t get_capacity_by_tag(const uint8_t tag) {
-  // Part 1 Table 7 Container Minimum Capacity, 5FC1XX
-  switch (tag) {
-  case 0x05: // X.509 Certificate for PIV Authentication (9A)
-  case 0x0A: // X.509 Certificate for Digital Signature (9C)
-  case 0x0B: // X.509 Certificate for Key Management (9D)
-  case 0x01: // X.509 Certificate for Card Authentication (9E)
-  case 0x0D: // Retired X.509 Certificate for Key Management 1 (82)
-  case 0x0E: // Retired X.509 Certificate for Key Management 2 (83)
-    return 3000;
-  case 0x02: // Card Holder Unique Identifier
-    return 2916;
-  case 0x07: // Card Capability Container
-    return 287;
-  case 0x09: // Printed Information
-    return 245;
-  case 0x03: // Fingerprints
-  case 0x08: // Facial Images
-    return 512;
-  default:
-    return 0;
-  }
-}
-
-static int is_certificate_object_tag(const uint8_t tag) {
-  switch (tag) {
-  case 0x05:
-  case 0x0A:
-  case 0x0B:
-  case 0x01:
-  case 0x0D:
-  case 0x0E:
-    return 1;
-  default:
-    return 0;
-  }
-}
-
 static int piv_select(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x04 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
 
   // reset internal states
   in_admin_status = 0;
   pin_is_consumed = 0;
+  piv_pin_protected_cache_clear();
   pin.is_validated = 0;
   puk.is_validated = 0;
   piv_do_write = -1;
@@ -723,11 +963,18 @@ static int piv_get_large_data(const CAPDU *capdu, RAPDU *rapdu, const char *path
  */
 static int piv_get_data(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x3F || P2 != 0xFF) EXCEPT(SW_WRONG_P1P2);
-  if (LC < 2) EXCEPT(SW_WRONG_LENGTH);
-  if (DATA[0] != 0x5C) EXCEPT(SW_WRONG_DATA);
-  if (DATA[1] + 2 != LC) EXCEPT(SW_WRONG_LENGTH);
-  if (DATA[1] == 1) {
-    if (DATA[2] != 0x7E) EXCEPT(SW_FILE_NOT_FOUND);
+  uint32_t tag;
+  uint16_t header_len;
+  const int tag_sw = piv_parse_data_object_tag(capdu, &tag, &header_len);
+  if (tag_sw != SW_NO_ERROR) EXCEPT(tag_sw);
+  if (header_len != LC) EXCEPT(SW_WRONG_LENGTH);
+
+  const piv_do_desc_t *desc = piv_find_do(tag);
+  if (desc == NULL) EXCEPT(SW_FILE_NOT_FOUND);
+
+  if ((desc->flags & PIV_DO_F_GET_PIN) != 0 && !pin.is_validated) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+
+  if (tag == PIV_DO_TAG_DISCOVERY) {
     // For the Discovery Object, the 0x7E template nests two data elements:
     // 1) tag 0x4F contains the AID of the PIV Card Application and
     // 2) tag 0x5F2F lists the PIN Usage Policy.
@@ -742,19 +989,25 @@ static int piv_get_data(const CAPDU *capdu, RAPDU *rapdu) {
     RDATA[6 + sizeof(rid) + sizeof(pix)] = sizeof(pin_policy);
     memcpy(RDATA + 7 + sizeof(rid) + sizeof(pix), pin_policy, sizeof(pin_policy));
     LL = 7 + sizeof(rid) + sizeof(pix) + sizeof(pin_policy);
-  } else if (DATA[1] == 3) {
-    if (LC != 5 || DATA[2] != 0x5F || DATA[3] != 0xC1) EXCEPT(SW_FILE_NOT_FOUND);
-    // Reading Printed Information, Fingerprints, and Facial Images requires PIN verification
-    if ((DATA[4] == 0x09 || DATA[4] == 0x03 || DATA[4] == 0x08) && !pin.is_validated)
-      EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
-    const char *path = get_object_path_by_tag(DATA[4]);
-    if (path == NULL) EXCEPT(SW_FILE_NOT_FOUND);
-    const int size = get_file_size(path);
-    if (size < 0) return -1;
-    if (size == 0) EXCEPT(SW_FILE_NOT_FOUND);
-    return piv_get_large_data(capdu, rapdu, path, size);
-  } else
-    EXCEPT(SW_FILE_NOT_FOUND);
+    return 0;
+  }
+
+  if ((desc->flags & PIV_DO_F_INLINE) != 0) {
+    const int attr_len = read_attr(CARD_ADMIN_KEY_PATH, desc->attr, RDATA, desc->capacity);
+    if (attr_len > 0) {
+      LL = attr_len;
+      return 0;
+    }
+    if (attr_len < 0 && desc->path == NULL) EXCEPT(SW_FILE_NOT_FOUND);
+  }
+
+  char path[MAX_DO_PATH_LEN];
+  if (!piv_do_get_path(desc, tag, path)) EXCEPT(SW_FILE_NOT_FOUND);
+  const int size = get_file_size(path);
+  if (size == LFS_ERR_NOENT || size == 0) EXCEPT(SW_FILE_NOT_FOUND);
+  if (size < 0) return -1;
+  return piv_get_large_data(capdu, rapdu, path, size);
+
   return 0;
 }
 
@@ -1186,33 +1439,58 @@ static int piv_general_authenticate(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
 
   if (P1 != 0x3F || P2 != 0xFF) EXCEPT(SW_WRONG_P1P2);
 
   if (piv_do_write == -1) { // not in chaining write
-    if (LC < 5) EXCEPT(SW_WRONG_LENGTH);
-    const int size = LC - 5;
-    if (DATA[0] != 0x5C) EXCEPT(SW_WRONG_DATA);
-    // Part 1 Table 3 0x5FC1XX
-    if (DATA[1] != 3 || DATA[2] != 0x5F || DATA[3] != 0xC1) EXCEPT(SW_FILE_NOT_FOUND);
-    const char *path = get_object_path_by_tag(DATA[4]);
-    const int max_len = get_capacity_by_tag(DATA[4]);
-    if (path == NULL) EXCEPT(SW_FILE_NOT_FOUND);
-    if (size > max_len) EXCEPT(SW_WRONG_LENGTH);
-    if ((CLA & 0x10) == 0 && is_certificate_object_tag(DATA[4]) && size == 2 && DATA[5] == 0x53 && DATA[6] == 0x00) {
+    uint32_t tag;
+    uint16_t header_len;
+    const int tag_sw = piv_parse_data_object_tag(capdu, &tag, &header_len);
+    if (tag_sw != SW_NO_ERROR) EXCEPT(tag_sw);
+
+    const piv_do_desc_t *desc = piv_find_do(tag);
+    if (desc == NULL || (desc->flags & (PIV_DO_F_READ_ONLY | PIV_DO_F_PUT_ADMIN)) != PIV_DO_F_PUT_ADMIN)
+      EXCEPT(SW_FILE_NOT_FOUND);
+
+    const uint16_t size = LC - header_len;
+    if (size > desc->capacity) EXCEPT(SW_WRONG_LENGTH);
+    const uint8_t *payload = DATA + header_len;
+
+    if ((desc->flags & PIV_DO_F_INLINE) != 0 && size <= piv_do_inline_capacity(desc)) {
+      if ((CLA & 0x10) != 0) EXCEPT(SW_WRONG_LENGTH);
+      if (piv_do_write_inline(desc, payload, size) < 0) return -1;
+      if (tag == PIV_DO_TAG_FF(0x00) || tag == PIV_DO_TAG_C1(0x09)) piv_pin_protected_cache_clear();
+      return 0;
+    }
+
+    if ((desc->flags & PIV_DO_F_INLINE) != 0 && desc->path == NULL) {
+      EXCEPT(SW_WRONG_LENGTH);
+    }
+
+    if ((desc->flags & PIV_DO_F_INLINE) != 0 && write_attr(CARD_ADMIN_KEY_PATH, desc->attr, NULL, 0) < 0) {
+      return -1;
+    }
+
+    if (tag == PIV_DO_TAG_FF(0x00) || tag == PIV_DO_TAG_C1(0x09)) {
+      piv_pin_protected_cache_clear();
+    }
+
+    char path[MAX_DO_PATH_LEN];
+    if (!piv_do_get_path(desc, tag, path)) EXCEPT(SW_FILE_NOT_FOUND);
+    if ((CLA & 0x10) == 0 && (desc->flags & PIV_DO_F_CERT) != 0 && size == 2 && payload[0] == 0x53 &&
+        payload[1] == 0x00) {
       DBG_MSG("delete certificate file %s\n", path);
-      const int rc = write_file(path, NULL, 0, 0, 1);
-      if (rc < 0) return -1;
+      if (piv_remove_file_if_present(path) < 0) return -1;
       return 0;
     }
     DBG_MSG("write file %s, first chunk length %d\n", path, size);
-    const int rc = write_file(path, DATA + 5, 0, size, 1);
+    const int rc = write_file(path, payload, 0, size, 1);
     if (rc < 0) return -1;
-    if ((CLA & 0x10) != 0 && size < max_len) {
+    if ((CLA & 0x10) != 0 && size < desc->capacity) {
       // enter chaining write mode
-      piv_do_write = max_len - size;
+      piv_do_write = desc->capacity - size;
       strcpy(piv_do_path, path);
     }
   } else {
@@ -1240,7 +1518,7 @@ static int piv_put_data(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_generate_asymmetric_key_pair(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
   if (LC < 5) {
     DBG_MSG("Wrong length\n");
@@ -1291,11 +1569,12 @@ static int piv_set_management_key(const CAPDU *capdu, RAPDU *rapdu) {
   if (LC != 27) EXCEPT(SW_WRONG_LENGTH);
   if (DATA[0] != 0x03 || DATA[1] != 0x9B || DATA[2] != 24) EXCEPT(SW_WRONG_DATA);
 #ifndef FUZZ
-  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
   if (write_file(CARD_ADMIN_KEY_PATH, DATA + 3, 0, 24, 1) < 0) return -1;
   const uint8_t is_default = !memcmp(DATA + 3, DEFAULT_MGMT_KEY, 24);
   if (write_attr(CARD_ADMIN_KEY_PATH, TAG_PIN_KEY_DEFAULT, &is_default, sizeof(is_default)) < 0) return -1;
+  if (piv_pin_protected_configured() && piv_write_pin_protected_management_key(DATA + 3, 24) < 0) return -1;
   return 0;
 }
 
@@ -1309,7 +1588,7 @@ static int piv_reset(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_import_asymmetric_key(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
   const char *key_path = get_key_path(P2);
   if (key_path == NULL || P2 == 0x9B) {
@@ -1512,7 +1791,7 @@ static int piv_get_serial(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int piv_algorithm_extension(const CAPDU *capdu, RAPDU *rapdu) {
 #ifndef FUZZ
-  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+  if (!piv_admin_status_satisfied()) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
 #endif
 
   if (P1 != 0x01 && P1 != 0x02) EXCEPT(SW_WRONG_P1P2);

--- a/include/fs.h
+++ b/include/fs.h
@@ -16,6 +16,7 @@ int read_attr(const char *path, uint8_t attr, void *buf, lfs_size_t len);
 int write_attr(const char *path, uint8_t attr, const void *buf, lfs_size_t len);
 int get_file_size(const char *path);
 int fs_rename(const char *old, const char *new);
+int remove_file(const char *path);
 
 /**
  * Get the total size (in KiB) of the file system.

--- a/include/fs.h
+++ b/include/fs.h
@@ -14,6 +14,7 @@ int append_file(const char *path, const void *buf, lfs_size_t len);
 int truncate_file(const char *path, lfs_size_t len);
 int read_attr(const char *path, uint8_t attr, void *buf, lfs_size_t len);
 int write_attr(const char *path, uint8_t attr, const void *buf, lfs_size_t len);
+int remove_attr(const char *path, uint8_t attr);
 int get_file_size(const char *path);
 int fs_rename(const char *old, const char *new);
 int remove_file(const char *path);

--- a/src/fs.c
+++ b/src/fs.c
@@ -99,6 +99,10 @@ int write_attr(const char *path, uint8_t attr, const void *buf, lfs_size_t len) 
   return lfs_setattr(&lfs, path, attr, buf, len);
 }
 
+int remove_attr(const char *path, uint8_t attr) {
+  return lfs_removeattr(&lfs, path, attr);
+}
+
 int get_file_size(const char *path) {
   lfs_file_t f;
   int err = lfs_file_opencfg(&lfs, &f, path, LFS_O_RDONLY, &file_config);

--- a/src/fs.c
+++ b/src/fs.c
@@ -125,3 +125,5 @@ int get_fs_usage(void) {
 }
 
 int fs_rename(const char *old, const char *new) { return lfs_rename(&lfs, old, new); }
+
+int remove_file(const char *path) { return lfs_remove(&lfs, path); }

--- a/test/test_piv.c
+++ b/test/test_piv.c
@@ -198,6 +198,23 @@ static void test_piv_pin_protected_admin_from_pin(void **state) {
   assert_int_equal(get_file_size("piv-pauc"), 3);
 }
 
+static void test_piv_pin_logout_revokes_pin_protected_admin(void **state) {
+  (void)state;
+  assert_int_equal(piv_install(1), 0);
+  configure_pin_protected_default_key();
+  piv_poweroff();
+
+  test_helper((uint8_t *)default_piv_pin, sizeof(default_piv_pin), PIV_INS_VERIFY, 0x00, 0x80, SW_NO_ERROR);
+
+  uint8_t put_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x05, 0x53, 0x01, 0xAA};
+  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+
+  test_helper(NULL, 0, PIV_INS_VERIFY, 0xFF, 0x80, SW_NO_ERROR);
+
+  uint8_t put_sig_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x0A, 0x53, 0x01, 0xBB};
+  test_helper(put_sig_cert, sizeof(put_sig_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_SECURITY_STATUS_NOT_SATISFIED);
+}
+
 static void test_piv_retired_cert_lazy_storage(void **state) {
   (void)state;
   assert_int_equal(piv_install(1), 0);
@@ -497,6 +514,7 @@ int main() {
       cmocka_unit_test(test_delete_certificate_object),
       cmocka_unit_test(test_piv_pin_protected_data_objects),
       cmocka_unit_test(test_piv_pin_protected_admin_from_pin),
+      cmocka_unit_test(test_piv_pin_logout_revokes_pin_protected_admin),
       cmocka_unit_test(test_piv_retired_cert_lazy_storage),
       cmocka_unit_test(test_piv_metadata_bounded_do_storage),
       cmocka_unit_test(test_piv_get_metadata_extended_algo_ids),

--- a/test/test_piv.c
+++ b/test/test_piv.c
@@ -142,7 +142,118 @@ static void test_delete_certificate_object(void **state) {
 
   uint8_t delete_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x05, 0x53, 0x00};
   test_helper(delete_cert, sizeof(delete_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
-  assert_int_equal(get_file_size("piv-pauc"), 0);
+  assert_true(get_file_size("piv-pauc") < 0);
+}
+
+static const uint8_t default_piv_pin[8] = {'1', '2', '3', '4', '5', '6', 0xFF, 0xFF};
+static const uint8_t default_mgmt_key[24] = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
+
+static void configure_pin_protected_default_key(void) {
+  set_admin_status(1);
+
+  uint8_t printed[5 + 30] = {0x5C, 0x03, 0x5F, 0xC1, 0x09, 0x53, 0x1C, 0x88, 0x1A, 0x89, 0x18};
+  memcpy(printed + 11, default_mgmt_key, sizeof(default_mgmt_key));
+  test_helper(printed, sizeof(printed), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+
+  uint8_t admin_data[] = {0x5C, 0x03, 0x5F, 0xFF, 0x00, 0x53, 0x05, 0x80, 0x03, 0x81, 0x01, 0x03};
+  test_helper(admin_data, sizeof(admin_data), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+
+  set_admin_status(0);
+}
+
+static void test_piv_pin_protected_data_objects(void **state) {
+  (void)state;
+  assert_int_equal(piv_install(1), 0);
+  configure_pin_protected_default_key();
+  piv_poweroff();
+
+  uint8_t get_printed[] = {0x5C, 0x03, 0x5F, 0xC1, 0x09};
+  test_helper(get_printed, sizeof(get_printed), PIV_INS_GET_DATA, 0x3F, 0xFF, SW_SECURITY_STATUS_NOT_SATISFIED);
+
+  test_helper((uint8_t *)default_piv_pin, sizeof(default_piv_pin), PIV_INS_VERIFY, 0x00, 0x80, SW_NO_ERROR);
+
+  uint8_t expected_printed[30] = {0x53, 0x1C, 0x88, 0x1A, 0x89, 0x18};
+  memcpy(expected_printed + 6, default_mgmt_key, sizeof(default_mgmt_key));
+  test_helper_resp(get_printed, sizeof(get_printed), PIV_INS_GET_DATA, 0x3F, 0xFF, SW_NO_ERROR, expected_printed,
+                   sizeof(expected_printed));
+
+  piv_poweroff();
+  uint8_t get_admin[] = {0x5C, 0x03, 0x5F, 0xFF, 0x00};
+  uint8_t expected_admin[] = {0x53, 0x05, 0x80, 0x03, 0x81, 0x01, 0x03};
+  test_helper_resp(get_admin, sizeof(get_admin), PIV_INS_GET_DATA, 0x3F, 0xFF, SW_NO_ERROR, expected_admin,
+                   sizeof(expected_admin));
+}
+
+static void test_piv_pin_protected_admin_from_pin(void **state) {
+  (void)state;
+  assert_int_equal(piv_install(1), 0);
+  configure_pin_protected_default_key();
+  piv_poweroff();
+
+  uint8_t put_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x05, 0x53, 0x01, 0xAA};
+  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_SECURITY_STATUS_NOT_SATISFIED);
+
+  test_helper((uint8_t *)default_piv_pin, sizeof(default_piv_pin), PIV_INS_VERIFY, 0x00, 0x80, SW_NO_ERROR);
+  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+  assert_int_equal(get_file_size("piv-pauc"), 3);
+}
+
+static void test_piv_retired_cert_lazy_storage(void **state) {
+  (void)state;
+  assert_int_equal(piv_install(1), 0);
+  assert_true(get_file_size("piv-r20") < 0);
+
+  set_admin_status(1);
+  uint8_t put_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x20, 0x53, 0x01, 0x55};
+  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+  assert_int_equal(get_file_size("piv-r20"), 3);
+
+  uint8_t get_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x20};
+  uint8_t expected[] = {0x53, 0x01, 0x55};
+  uint8_t r_buf[256];
+  CAPDU C = {.data = get_cert, .ins = PIV_INS_GET_DATA, .p1 = 0x3F, .p2 = 0xFF, .lc = sizeof(get_cert), .le = 256};
+  RAPDU R = {.data = r_buf};
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_int_equal(R.len, sizeof(expected));
+  assert_memory_equal(R.data, expected, sizeof(expected));
+}
+
+static void test_piv_metadata_bounded_do_storage(void **state) {
+  (void)state;
+  assert_int_equal(piv_install(1), 0);
+  set_admin_status(1);
+
+  uint8_t inline_printed[5 + 64] = {0x5C, 0x03, 0x5F, 0xC1, 0x09};
+  for (size_t i = 5; i < sizeof(inline_printed); ++i) {
+    inline_printed[i] = (uint8_t)i;
+  }
+  test_helper(inline_printed, sizeof(inline_printed), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+  assert_true(get_file_size("piv-pi") < 0);
+
+  uint8_t max_admin_data[5 + 128] = {0x5C, 0x03, 0x5F, 0xFF, 0x00};
+  for (size_t i = 5; i < sizeof(max_admin_data); ++i) {
+    max_admin_data[i] = (uint8_t)(0x80 + i);
+  }
+  test_helper(max_admin_data, sizeof(max_admin_data), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+
+  uint8_t large_printed[5 + 80] = {0x5C, 0x03, 0x5F, 0xC1, 0x09};
+  for (size_t i = 5; i < sizeof(large_printed); ++i) {
+    large_printed[i] = (uint8_t)i;
+  }
+  test_helper(large_printed, sizeof(large_printed), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+  assert_int_equal(get_file_size("piv-pi"), 80);
+
+  uint8_t security[] = {0x5C, 0x03, 0x5F, 0xC1, 0x06, 0x53, 0x02, 0x11, 0x22};
+  test_helper(security, sizeof(security), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+  assert_int_equal(get_file_size("piv-sec"), 4);
+
+  uint8_t key_history[] = {0x5C, 0x03, 0x5F, 0xC1, 0x0C, 0x53, 0x01, 0x33};
+  test_helper(key_history, sizeof(key_history), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
+  assert_int_equal(get_file_size("piv-kh"), 3);
+
+  configure_pin_protected_default_key();
+  assert_true(get_file_size("piv-pi") < 0);
 }
 
 // piv_get_metadata's key_type_to_algo_id switch maps each supported
@@ -249,7 +360,8 @@ static void test_piv_cert_chained_read(void **state) {
   // 600-byte payload large enough to span three 256-byte chunks.
   enum { CERT_LEN = 600 };
   uint8_t cert[CERT_LEN];
-  for (size_t i = 0; i < CERT_LEN; ++i) cert[i] = (uint8_t)(0xC0 + (i & 0x3F));
+  for (size_t i = 0; i < CERT_LEN; ++i)
+    cert[i] = (uint8_t)(0xC0 + (i & 0x3F));
 
   uint8_t r_buf[1024];
   RAPDU rapdu = {.data = r_buf};
@@ -271,8 +383,13 @@ static void test_piv_cert_chained_read(void **state) {
   first_data[8] = (uint8_t)(CERT_LEN & 0xFF);
   memcpy(first_data + HDR_LEN, cert, FIRST_CHUNK);
   CAPDU put_first = {
-      .data = first_data, .cla = 0x10, .ins = PIV_INS_PUT_DATA, .p1 = 0x3F, .p2 = 0xFF,
-      .lc = sizeof(first_data), .le = 0,
+      .data = first_data,
+      .cla = 0x10,
+      .ins = PIV_INS_PUT_DATA,
+      .p1 = 0x3F,
+      .p2 = 0xFF,
+      .lc = sizeof(first_data),
+      .le = 0,
   };
   rc.rapdu.len = 0;
   rc.sent = 0;
@@ -307,7 +424,13 @@ static void test_piv_cert_chained_read(void **state) {
   // Now read it back via GET DATA + GET RESPONSE chain.
   uint8_t get_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x05};
   CAPDU get_apdu = {
-      .data = get_cert, .cla = 0x00, .ins = PIV_INS_GET_DATA, .p1 = 0x3F, .p2 = 0xFF, .lc = sizeof(get_cert), .le = 0x100,
+      .data = get_cert,
+      .cla = 0x00,
+      .ins = PIV_INS_GET_DATA,
+      .p1 = 0x3F,
+      .p2 = 0xFF,
+      .lc = sizeof(get_cert),
+      .le = 0x100,
   };
   rc.rapdu.len = 0;
   rc.sent = 0;
@@ -372,6 +495,10 @@ int main() {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_regression_fuzz),
       cmocka_unit_test(test_delete_certificate_object),
+      cmocka_unit_test(test_piv_pin_protected_data_objects),
+      cmocka_unit_test(test_piv_pin_protected_admin_from_pin),
+      cmocka_unit_test(test_piv_retired_cert_lazy_storage),
+      cmocka_unit_test(test_piv_metadata_bounded_do_storage),
       cmocka_unit_test(test_piv_get_metadata_extended_algo_ids),
       cmocka_unit_test(test_ed25519_general_authenticate_long_message),
       cmocka_unit_test(test_piv_cert_chained_read),

--- a/test/test_piv.c
+++ b/test/test_piv.c
@@ -148,7 +148,7 @@ static void test_delete_certificate_object(void **state) {
 static const uint8_t default_piv_pin[8] = {'1', '2', '3', '4', '5', '6', 0xFF, 0xFF};
 static const uint8_t default_mgmt_key[24] = {1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8};
 
-static void configure_pin_protected_default_key(void) {
+static void configure_host_managed_admin_data(void) {
   set_admin_status(1);
 
   uint8_t printed[5 + 30] = {0x5C, 0x03, 0x5F, 0xC1, 0x09, 0x53, 0x1C, 0x88, 0x1A, 0x89, 0x18};
@@ -161,10 +161,12 @@ static void configure_pin_protected_default_key(void) {
   set_admin_status(0);
 }
 
-static void test_piv_pin_protected_data_objects(void **state) {
+static void test_piv_host_managed_admin_data_objects(void **state) {
   (void)state;
   assert_int_equal(piv_install(1), 0);
-  configure_pin_protected_default_key();
+  const int admin_key_size = get_file_size("piv-admk");
+  configure_host_managed_admin_data();
+  assert_int_equal(get_file_size("piv-admk"), admin_key_size);
   piv_poweroff();
 
   uint8_t get_printed[] = {0x5C, 0x03, 0x5F, 0xC1, 0x09};
@@ -184,35 +186,18 @@ static void test_piv_pin_protected_data_objects(void **state) {
                    sizeof(expected_admin));
 }
 
-static void test_piv_pin_protected_admin_from_pin(void **state) {
+static void test_piv_pin_does_not_satisfy_admin(void **state) {
   (void)state;
   assert_int_equal(piv_install(1), 0);
-  configure_pin_protected_default_key();
+  configure_host_managed_admin_data();
   piv_poweroff();
 
   uint8_t put_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x05, 0x53, 0x01, 0xAA};
   test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_SECURITY_STATUS_NOT_SATISFIED);
 
   test_helper((uint8_t *)default_piv_pin, sizeof(default_piv_pin), PIV_INS_VERIFY, 0x00, 0x80, SW_NO_ERROR);
-  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
-  assert_int_equal(get_file_size("piv-pauc"), 3);
-}
-
-static void test_piv_pin_logout_revokes_pin_protected_admin(void **state) {
-  (void)state;
-  assert_int_equal(piv_install(1), 0);
-  configure_pin_protected_default_key();
-  piv_poweroff();
-
-  test_helper((uint8_t *)default_piv_pin, sizeof(default_piv_pin), PIV_INS_VERIFY, 0x00, 0x80, SW_NO_ERROR);
-
-  uint8_t put_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x05, 0x53, 0x01, 0xAA};
-  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
-
-  test_helper(NULL, 0, PIV_INS_VERIFY, 0xFF, 0x80, SW_NO_ERROR);
-
-  uint8_t put_sig_cert[] = {0x5C, 0x03, 0x5F, 0xC1, 0x0A, 0x53, 0x01, 0xBB};
-  test_helper(put_sig_cert, sizeof(put_sig_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_SECURITY_STATUS_NOT_SATISFIED);
+  test_helper(put_cert, sizeof(put_cert), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_SECURITY_STATUS_NOT_SATISFIED);
+  assert_true(get_file_size("piv-pauc") < 0);
 }
 
 static void test_piv_retired_cert_lazy_storage(void **state) {
@@ -269,7 +254,7 @@ static void test_piv_metadata_bounded_do_storage(void **state) {
   test_helper(key_history, sizeof(key_history), PIV_INS_PUT_DATA, 0x3F, 0xFF, SW_NO_ERROR);
   assert_int_equal(get_file_size("piv-kh"), 3);
 
-  configure_pin_protected_default_key();
+  configure_host_managed_admin_data();
   assert_true(get_file_size("piv-pi") < 0);
 }
 
@@ -512,9 +497,8 @@ int main() {
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_regression_fuzz),
       cmocka_unit_test(test_delete_certificate_object),
-      cmocka_unit_test(test_piv_pin_protected_data_objects),
-      cmocka_unit_test(test_piv_pin_protected_admin_from_pin),
-      cmocka_unit_test(test_piv_pin_logout_revokes_pin_protected_admin),
+      cmocka_unit_test(test_piv_host_managed_admin_data_objects),
+      cmocka_unit_test(test_piv_pin_does_not_satisfy_admin),
       cmocka_unit_test(test_piv_retired_cert_lazy_storage),
       cmocka_unit_test(test_piv_metadata_bounded_do_storage),
       cmocka_unit_test(test_piv_get_metadata_extended_algo_ids),


### PR DESCRIPTION
## Summary

- Add a table-driven PIV data object model with lazy LittleFS storage for missing PIV DOs, including SECURITY, KEY HISTORY, IRIS, and retired key-management certificates.
- Store normally-small host-managed ADMIN DATA and PRINTED DO payloads in a dedicated `piv-do` metadata file, bounded for 512-byte LittleFS metadata blocks; larger PRINTED payloads fall back to `piv-pi`.
- Keep the management key storage unchanged in `piv-admk`, and keep admin authorization tied to normal management-key authentication only.
- Treat PIN-only mode and PUK blocking as host-managed state: firmware stores/returns the relevant DOs and enforces read/write access rules, but does not infer admin state, update management keys, or block the PUK from ADMIN DATA/PRINTED contents.
- Add a `remove_attr()` FS helper so stale inline DO attrs are actually removed instead of leaving zero-length metadata entries behind.

## PIV Data Objects

| Object | OID | ID | Access | Storage |
|---|---|---:|---|---|
| Discovery Object | 2.16.840.1.101.3.7.2.96.80 | `0x7e` | read-only | synthesized |
| BIT Group Template | n/a | `0x7f61` | read-only | returns not found |
| X.509 Certificate for Card Authentication | 2.16.840.1.101.3.7.2.5.0 | `0x5fc101` | admin write, public read | `piv-cauc`, lazy file |
| Card Holder Unique Identifier | 2.16.840.1.101.3.7.2.48.0 | `0x5fc102` | admin write, public read | `piv-chu`, default file |
| Cardholder Fingerprints | 2.16.840.1.101.3.7.2.96.16 | `0x5fc103` | admin write, PIN read | `piv-fig`, lazy file |
| X.509 Certificate for PIV Authentication | 2.16.840.1.101.3.7.2.1.1 | `0x5fc105` | admin write, public read | `piv-pauc`, lazy file |
| Security Object | 2.16.840.1.101.3.7.2.144.0 | `0x5fc106` | admin write, public read | `piv-sec`, lazy file |
| Card Capability Container | 2.16.840.1.101.3.7.1.219.0 | `0x5fc107` | admin write, public read | `piv-ccc`, default file |
| Cardholder Facial Image | 2.16.840.1.101.3.7.2.96.48 | `0x5fc108` | admin write, PIN read | `piv-face`, lazy file |
| Printed Information | 2.16.840.1.101.3.7.2.48.1 | `0x5fc109` | admin write, PIN read | `piv-do` attr when <= 64 B, otherwise `piv-pi` |
| X.509 Certificate for Digital Signature | 2.16.840.1.101.3.7.2.1.0 | `0x5fc10a` | admin write, public read | `piv-sigc`, lazy file |
| X.509 Certificate for Key Management | 2.16.840.1.101.3.7.2.1.2 | `0x5fc10b` | admin write, public read | `piv-mntc`, lazy file |
| Key History Object | 2.16.840.1.101.3.7.2.96.96 | `0x5fc10c` | admin write, public read | `piv-kh`, lazy file |
| Retired X.509 Certificate for Key Management | 2.16.840.1.101.3.7.2.16.1-20 | `0x5fc10d`-`0x5fc120` | admin write, public read | generated `piv-rXX`, lazy file |
| Cardholder Iris Images | 2.16.840.1.101.3.7.2.16.21 | `0x5fc121` | admin write, PIN read | `piv-iris`, lazy file |
| ADMIN DATA | n/a | `0x5fff00` | admin write, public read | `piv-do` attr, max 128 B |

## Tests

- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `git diff --check`
