### PR TITLE
Host-managed KBDHID ASCII keymap and device configuration refactoring

### DIFF
--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -54,42 +54,6 @@ __attribute__((weak)) int admin_vendor_nfc_enable(const CAPDU *capdu, RAPDU *rap
   return 0;
 }
 
-__weak int admin_platform_device_config_read(admin_device_config_t *cfg) {
-  UNUSED(cfg);
-  return -1;
-}
-
-__weak int admin_platform_device_config_write(const admin_device_config_t *cfg) {
-  UNUSED(cfg);
-  return -1;
-}
-
-__weak int admin_platform_serial_read(uint8_t *buf) {
-  UNUSED(buf);
-  return -1;
-}
-
-__weak int admin_platform_serial_write_once(const uint8_t *buf) {
-  UNUSED(buf);
-  return -1;
-}
-
-__weak int admin_platform_kbd_keymap_write(uint8_t layout_id, const uint8_t *keymap, uint16_t len) {
-  UNUSED(layout_id);
-  UNUSED(keymap);
-  UNUSED(len);
-  return -1;
-}
-
-__weak int admin_platform_kbd_keymap_read(uint8_t *layout_id, uint8_t *keymap, uint16_t len) {
-  UNUSED(layout_id);
-  UNUSED(keymap);
-  UNUSED(len);
-  return -1;
-}
-
-__weak int admin_platform_kbd_keymap_clear(void) { return -1; }
-
 // Query the platform hook on every read so a platform-backed config is not
 // shadowed by core RAM after a vendor/admin APDU updates flash directly.
 uint8_t device_config_is_led_normally_on(void) { return admin_get_current_config().led_normally_on; }

--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -2,6 +2,7 @@
 #include <admin.h>
 #include <crypto-util.h>
 #include <ctap.h>
+#include <device-config.h>
 #include <device.h>
 #include <fs.h>
 #if ENABLE_APPLET_NDEF
@@ -14,14 +15,13 @@
 #include <piv.h>
 
 #define PIN_RETRY_COUNTER 3
-#define SN_FILE "sn"
-#define CFG_FILE "admin_cfg"
 
 static pin_t pin = {.min_length = 6, .max_length = PIN_MAX_LENGTH, .is_validated = 0, .path = "admin-pin"};
 
 static const admin_device_config_t default_cfg = {.led_normally_on = 1, .ndef_en = 1, .webusb_landing_en = 1};
 
 static admin_device_config_t current_config;
+static admin_device_config_t admin_get_current_config(void);
 
 __attribute__((weak)) int admin_vendor_specific(const CAPDU *capdu, RAPDU *rapdu) {
   UNUSED(capdu);
@@ -54,21 +54,65 @@ __attribute__((weak)) int admin_vendor_nfc_enable(const CAPDU *capdu, RAPDU *rap
   return 0;
 }
 
-uint8_t cfg_is_led_normally_on(void) { return current_config.led_normally_on; }
+__weak int admin_platform_device_config_read(admin_device_config_t *cfg) {
+  UNUSED(cfg);
+  return -1;
+}
 
-uint8_t cfg_is_ndef_enable(void) { return current_config.ndef_en; }
+__weak int admin_platform_device_config_write(const admin_device_config_t *cfg) {
+  UNUSED(cfg);
+  return -1;
+}
 
-uint8_t cfg_is_webusb_landing_enable(void) { return current_config.webusb_landing_en; }
+__weak int admin_platform_serial_read(uint8_t *buf) {
+  UNUSED(buf);
+  return -1;
+}
+
+__weak int admin_platform_serial_write_once(const uint8_t *buf) {
+  UNUSED(buf);
+  return -1;
+}
+
+__weak int admin_platform_kbd_keymap_write(uint8_t layout_id, const uint8_t *keymap, uint16_t len) {
+  UNUSED(layout_id);
+  UNUSED(keymap);
+  UNUSED(len);
+  return -1;
+}
+
+__weak int admin_platform_kbd_keymap_read(uint8_t *layout_id, uint8_t *keymap, uint16_t len) {
+  UNUSED(layout_id);
+  UNUSED(keymap);
+  UNUSED(len);
+  return -1;
+}
+
+__weak int admin_platform_kbd_keymap_clear(void) { return -1; }
+
+// Query the platform hook on every read so a platform-backed config is not
+// shadowed by core RAM after a vendor/admin APDU updates flash directly.
+uint8_t device_config_is_led_normally_on(void) { return admin_get_current_config().led_normally_on; }
+
+uint8_t device_config_is_ndef_enabled(void) { return admin_get_current_config().ndef_en; }
+
+uint8_t device_config_is_webusb_landing_enabled(void) { return admin_get_current_config().webusb_landing_en; }
+
+static admin_device_config_t admin_get_current_config(void) {
+  admin_device_config_t cfg = default_cfg;
+  if (admin_platform_device_config_read(&cfg) == 0) return cfg;
+  return default_cfg;
+}
 
 void admin_poweroff(void) { pin.is_validated = 0; }
 
 int admin_install(const uint8_t reset) {
   admin_poweroff();
-  if (reset || get_file_size(CFG_FILE) != sizeof(admin_device_config_t)) {
+  // Device config is platform-backed. Core keeps no LittleFS fallback, which
+  // avoids two independent sources of truth for LED/NDEF/WebUSB flags.
+  if (reset || admin_platform_device_config_read(&current_config) < 0) {
     current_config = default_cfg;
-    if (write_file(CFG_FILE, &current_config, 0, sizeof(current_config), 1) < 0) return -1;
-  } else {
-    if (read_file(CFG_FILE, &current_config, 0, sizeof(current_config)) < 0) return -1;
+    if (admin_platform_device_config_write(&current_config) < 0) return -1;
   }
   if (reset || get_file_size(pin.path) < 0) {
     if (pin_create(&pin, "123456", 6, PIN_RETRY_COUNTER) < 0) return -1;
@@ -104,21 +148,22 @@ static int admin_change_pin(const CAPDU *capdu, RAPDU *rapdu) {
 static int admin_write_sn(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x00 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
   if (LC != 0x04) EXCEPT(SW_WRONG_LENGTH);
-  if (get_file_size(SN_FILE) >= 0) EXCEPT(SW_CONDITIONS_NOT_SATISFIED);
-  return write_file(SN_FILE, DATA, 0, LC, 1);
+  if (admin_platform_serial_write_once(DATA) < 0) EXCEPT(SW_CONDITIONS_NOT_SATISFIED);
+  return 0;
 }
 
 static int admin_read_sn(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x00 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
   if (LE < 4) EXCEPT(SW_WRONG_LENGTH);
 
-  fill_sn(RDATA);
+  device_config_fill_serial(RDATA);
   LL = 4;
 
   return 0;
 }
 
 static int admin_config(const CAPDU *capdu, RAPDU *rapdu) {
+  current_config = admin_get_current_config();
   switch (P1) {
   case ADMIN_P1_CFG_LED_ON:
     current_config.led_normally_on = P2 & 1;
@@ -132,24 +177,26 @@ static int admin_config(const CAPDU *capdu, RAPDU *rapdu) {
   default:
     EXCEPT(SW_WRONG_P1P2);
   }
-  const int ret = write_file(CFG_FILE, &current_config, 0, sizeof(current_config), 1);
+  const int ret = admin_platform_device_config_write(&current_config);
   stop_blinking();
   return ret;
 }
 
 static int admin_read_config(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x00 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
-  if (LE < 5) EXCEPT(SW_WRONG_LENGTH);
+  if (LE < 6) EXCEPT(SW_WRONG_LENGTH);
 
-  RDATA[0] = current_config.led_normally_on;
+  const admin_device_config_t cfg = admin_get_current_config();
+
+  RDATA[0] = cfg.led_normally_on;
   RDATA[1] = 0; // reserved
 #if ENABLE_APPLET_NDEF
-  RDATA[2] = ndef_get_read_only();
+  RDATA[2] = ndef_is_read_only();
 #else
   RDATA[2] = 0;
 #endif
-  RDATA[3] = current_config.ndef_en;
-  RDATA[4] = current_config.webusb_landing_en;
+  RDATA[3] = cfg.ndef_en;
+  RDATA[4] = cfg.webusb_landing_en;
   RDATA[5] = 0; // reserved
   LL = 6;
 
@@ -165,6 +212,44 @@ static int admin_flash_usage(const CAPDU *capdu, RAPDU *rapdu) {
   LL = 2;
 
   return 0;
+}
+
+static int admin_write_kbd_keymap(const CAPDU *capdu, RAPDU *rapdu) {
+  UNUSED(rapdu);
+  // Payload is 128 ASCII entries, each {modifier, HID usage}. P2 carries a
+  // host-defined layout id so tooling can identify what was installed.
+  if (P1 != 0x00) EXCEPT(SW_WRONG_P1P2);
+  if (LC != ADMIN_KBD_KEYMAP_LENGTH) EXCEPT(SW_WRONG_LENGTH);
+  return admin_platform_kbd_keymap_write(P2, DATA, LC);
+}
+
+static int admin_read_kbd_keymap(const CAPDU *capdu, RAPDU *rapdu) {
+  if (P1 != 0x00) EXCEPT(SW_WRONG_P1P2);
+  if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
+  switch (P2) {
+  case ADMIN_P2_KBD_READ_LAYOUT_ID:
+    if (LE < 1) EXCEPT(SW_WRONG_LENGTH);
+    if (admin_platform_kbd_keymap_read(RDATA, NULL, 0) < 0) EXCEPT(SW_REFERENCE_DATA_NOT_FOUND);
+    LL = 1;
+    return 0;
+  case ADMIN_P2_KBD_READ_KEYMAP: {
+    uint8_t layout_id;
+    if (LE < ADMIN_KBD_KEYMAP_LENGTH) EXCEPT(SW_WRONG_LENGTH);
+    if (admin_platform_kbd_keymap_read(&layout_id, RDATA, ADMIN_KBD_KEYMAP_LENGTH) < 0)
+      EXCEPT(SW_REFERENCE_DATA_NOT_FOUND);
+    LL = ADMIN_KBD_KEYMAP_LENGTH;
+    return 0;
+  }
+  default:
+    EXCEPT(SW_WRONG_P1P2);
+  }
+}
+
+static int admin_clear_kbd_keymap(const CAPDU *capdu, RAPDU *rapdu) {
+  UNUSED(rapdu);
+  if (P1 != 0x00 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
+  if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
+  return admin_platform_kbd_keymap_clear();
 }
 
 static int admin_factory_reset(const CAPDU *capdu, RAPDU *rapdu) {
@@ -201,9 +286,8 @@ static int admin_factory_reset(const CAPDU *capdu, RAPDU *rapdu) {
   return 0;
 }
 
-void fill_sn(uint8_t *buf) {
-  const int err = read_file(SN_FILE, buf, 0, 4);
-  if (err != 4) memset(buf, 0, 4);
+void device_config_fill_serial(uint8_t *buf) {
+  if (admin_platform_serial_read(buf) < 0) memset(buf, 0, 4);
 }
 
 int admin_process_apdu(const CAPDU *capdu, RAPDU *rapdu) {
@@ -326,6 +410,15 @@ int admin_process_apdu(const CAPDU *capdu, RAPDU *rapdu) {
 #else
     EXCEPT(SW_INS_NOT_SUPPORTED);
 #endif
+    break;
+  case ADMIN_INS_WRITE_KBD_KEYMAP:
+    ret = admin_write_kbd_keymap(capdu, rapdu);
+    break;
+  case ADMIN_INS_READ_KBD_KEYMAP:
+    ret = admin_read_kbd_keymap(capdu, rapdu);
+    break;
+  case ADMIN_INS_CLEAR_KBD_KEYMAP:
+    ret = admin_clear_kbd_keymap(capdu, rapdu);
     break;
   case ADMIN_INS_VENDOR_SPECIFIC:
     ret = admin_vendor_specific(capdu, rapdu);

--- a/applets/ctap/ctap-internal.h
+++ b/applets/ctap/ctap-internal.h
@@ -21,8 +21,6 @@
 #define PIN_CTR_ATTR    0x03
 #define KH_KEY_ATTR     0x04
 #define HE_KEY_ATTR     0x05
-#define SM2_ATTR        0x06
-#define CONFIG_ATTR     0x07
 #define DC_FILE         "ctap_dc"
 #define DC_GENERAL_ATTR 0x00
 #define DC_META_FILE    "ctap_dm"

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -98,7 +98,31 @@ static ctap_src_t current_cmd_src;
 // SM2 attr
 CTAP_sm2_attr ctap_sm2_attr;
 
-static void ctap_sm2_attr_set_default(void) {
+__weak int ctap_platform_sm2_config_read(void *cfg, size_t len) {
+  UNUSED(cfg);
+  UNUSED(len);
+  return -1;
+}
+
+__weak int ctap_platform_sm2_config_write(const void *cfg, size_t len) {
+  UNUSED(cfg);
+  UNUSED(len);
+  return -1;
+}
+
+__weak int ctap_platform_persistent_config_read(void *cfg, size_t len) {
+  UNUSED(cfg);
+  UNUSED(len);
+  return -1;
+}
+
+__weak int ctap_platform_persistent_config_write(const void *cfg, size_t len) {
+  UNUSED(cfg);
+  UNUSED(len);
+  return -1;
+}
+
+static void ctap_sm2_config_set_default(void) {
   ctap_sm2_attr.curve_id = 9;  // An unused one. See https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
   ctap_sm2_attr.algo_id = -54; // An unused one. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms
 }
@@ -107,19 +131,24 @@ static bool ctap_sm2_algo_id_valid(int32_t algo_id) {
   return algo_id != COSE_ALG_ES256 && algo_id != COSE_ALG_EDDSA && algo_id != COSE_ALG_ML_DSA_65;
 }
 
-static void ctap_sm2_attr_normalize(void) {
-  if (!ctap_sm2_algo_id_valid(ctap_sm2_attr.algo_id)) ctap_sm2_attr_set_default();
+static int ctap_sm2_config_read_platform(CTAP_sm2_attr *attr) {
+  if (ctap_platform_sm2_config_read(attr, sizeof(*attr)) < 0) return -1;
+  return ctap_sm2_algo_id_valid(attr->algo_id) ? 0 : -1;
 }
 
-static int ctap_sm2_attr_load(void) {
-  int ret = read_attr(CTAP_CERT_FILE, SM2_ATTR, &ctap_sm2_attr, sizeof(ctap_sm2_attr));
-  if (ret == (int)sizeof(ctap_sm2_attr)) {
-    ctap_sm2_attr_normalize();
-    return 0;
-  }
+static bool ctap_littlefs_state_present(void) {
+  uint8_t buf[KH_KEY_SIZE];
+  uint8_t pin_ctr;
+  CTAP_dc_general_attr attr;
+  const int pin_attr_len = read_attr(CTAP_CERT_FILE, PIN_ATTR, buf, sizeof(buf));
+  if (pin_attr_len != 0 && pin_attr_len != PIN_HASH_SIZE_P1) return false;
 
-  ctap_sm2_attr_set_default();
-  return write_attr(CTAP_CERT_FILE, SM2_ATTR, &ctap_sm2_attr, sizeof(ctap_sm2_attr));
+  return get_file_size(DC_FILE) >= 0 && get_file_size(DC_META_FILE) >= 0 && get_file_size(CTAP_CERT_FILE) >= 0 &&
+         get_file_size(LB_FILE) >= 0 && read_attr(DC_FILE, DC_GENERAL_ATTR, &attr, sizeof(attr)) == sizeof(attr) &&
+         read_attr(CTAP_CERT_FILE, SIGN_CTR_ATTR, buf, 4) == 4 &&
+         (pin_attr_len == 0 || read_attr(CTAP_CERT_FILE, PIN_CTR_ATTR, &pin_ctr, sizeof(pin_ctr)) == sizeof(pin_ctr)) &&
+         read_attr(CTAP_CERT_FILE, KH_KEY_ATTR, buf, KH_KEY_SIZE) == KH_KEY_SIZE &&
+         read_attr(CTAP_CERT_FILE, HE_KEY_ATTR, buf, HE_KEY_SIZE) == HE_KEY_SIZE;
 }
 
 typedef struct {
@@ -300,7 +329,7 @@ static void ctap_config_default(CTAP_persistent_config *cfg) {
 }
 
 static int ctap_config_store(const CTAP_persistent_config *cfg) {
-  return write_attr(CTAP_CERT_FILE, CONFIG_ATTR, cfg, sizeof(*cfg));
+  return ctap_platform_persistent_config_write(cfg, sizeof(*cfg));
 }
 
 static bool ctap_config_valid(const CTAP_persistent_config *cfg) {
@@ -309,10 +338,14 @@ static bool ctap_config_valid(const CTAP_persistent_config *cfg) {
          cfg->force_pin_change <= 1 && cfg->always_uv <= 1 && cfg->long_touch_for_reset <= 1;
 }
 
+static int ctap_config_read_platform(CTAP_persistent_config *cfg) {
+  if (ctap_platform_persistent_config_read(cfg, sizeof(*cfg)) < 0) return -1;
+  return ctap_config_valid(cfg) ? 0 : -1;
+}
+
 static int ctap_config_load(CTAP_persistent_config *cfg) {
   memset(cfg, 0, sizeof(*cfg));
-  int ret = read_attr(CTAP_CERT_FILE, CONFIG_ATTR, cfg, sizeof(*cfg));
-  if (ret == (int)sizeof(*cfg) && ctap_config_valid(cfg)) return 0;
+  if (ctap_config_read_platform(cfg) == 0) return 0;
 
   ctap_config_default(cfg);
   return 0;
@@ -914,8 +947,11 @@ void ctap_poweroff(void) {
 }
 
 uint8_t ctap_install(uint8_t reset) {
-  const bool has_persistent_state = get_file_size(LB_FILE) >= 0;
-  const bool runtime_reset = reset || runtime_reset_pending || !has_persistent_state;
+  CTAP_persistent_config persistent_cfg;
+  const bool has_littlefs_state = ctap_littlefs_state_present();
+  const bool has_complete_state = has_littlefs_state && ctap_sm2_config_read_platform(&ctap_sm2_attr) == 0 &&
+                                  ctap_config_read_platform(&persistent_cfg) == 0;
+  const bool runtime_reset = reset || runtime_reset_pending || !has_complete_state;
   // Reader reconnects may re-run ctap_install(0) without a real device reset.
   // Preserve in-flight CTAP command state in that case so CM/GA "next" commands
   // can continue across implicit PowerICC cycles.
@@ -929,15 +965,15 @@ uint8_t ctap_install(uint8_t reset) {
   }
   current_cmd_src = CTAP_SRC_NONE;
   if (runtime_reset) {
-    // PowerICC reconnects call ctap_install(0) while the NFC host may still be
-    // polling a 0x9100 keepalive response. Keep that pending request unless this
-    // is a real authenticator reset.
+    // PowerICC reconnects can call ctap_install(0) while an NFC host is still
+    // polling a keepalive response; keep that pending state on plain reconnect.
     ctap_nfc_pending_reset();
   }
   cp_initialize(runtime_reset);
   runtime_reset_pending = false;
-  if (!reset && has_persistent_state) {
-    if (ctap_sm2_attr_load() < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
+  // Platform-backed CTAP config is part of the install completion marker. If
+  // either platform config is absent or invalid, rebuild CTAP state.
+  if (!reset && has_complete_state) {
     DBG_MSG("CTAP initialized\n");
     return 0;
   }
@@ -957,14 +993,14 @@ uint8_t ctap_install(uint8_t reset) {
   if (write_attr(CTAP_CERT_FILE, KH_KEY_ATTR, kh_key, sizeof(kh_key)) < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
   random_buffer(kh_key, sizeof(kh_key));
   if (write_attr(CTAP_CERT_FILE, HE_KEY_ATTR, kh_key, sizeof(kh_key)) < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
-  ctap_sm2_attr_set_default();
-  if (write_attr(CTAP_CERT_FILE, SM2_ATTR, &ctap_sm2_attr, sizeof(ctap_sm2_attr)) < 0)
-    return CTAP2_ERR_UNHANDLED_REQUEST;
   memcpy(
       kh_key,
       (uint8_t[]){0x80, 0x76, 0xbe, 0x8b, 0x52, 0x8d, 0x00, 0x75, 0xf7, 0xaa, 0xe9, 0x8d, 0x6f, 0xa5, 0x7a, 0x6d, 0x3c},
       17);
   if (write_file(LB_FILE, kh_key, 0, 17, 1) < 0) return CTAP2_ERR_UNHANDLED_REQUEST;
+  ctap_sm2_config_set_default();
+  if (ctap_platform_sm2_config_write(&ctap_sm2_attr, sizeof(ctap_sm2_attr)) < 0)
+    return CTAP2_ERR_UNHANDLED_REQUEST;
   memzero(kh_key, sizeof(kh_key));
   DBG_MSG("CTAP reset and initialized\n");
   return 0;
@@ -973,8 +1009,8 @@ uint8_t ctap_install(uint8_t reset) {
 int ctap_install_private_key(const CAPDU *capdu, RAPDU *rapdu) {
   if (LC != PRI_KEY_SIZE) EXCEPT(SW_WRONG_LENGTH);
   // initialize SM2 config
-  ctap_sm2_attr_set_default();
-  if (write_attr(CTAP_CERT_FILE, SM2_ATTR, &ctap_sm2_attr, sizeof(ctap_sm2_attr)) < 0)
+  ctap_sm2_config_set_default();
+  if (ctap_platform_sm2_config_write(&ctap_sm2_attr, sizeof(ctap_sm2_attr)) < 0)
     return CTAP2_ERR_UNHANDLED_REQUEST;
   return write_attr(CTAP_CERT_FILE, KEY_ATTR, DATA, LC);
 }
@@ -1004,9 +1040,11 @@ int ctap_install_cert(const CAPDU *capdu, RAPDU *rapdu) {
 
 int ctap_read_sm2_config(const CAPDU *capdu, RAPDU *rapdu) {
   UNUSED(capdu);
-  const int ret = read_attr(CTAP_CERT_FILE, SM2_ATTR, RDATA, sizeof(ctap_sm2_attr));
+  CTAP_sm2_attr attr;
+  const int ret = ctap_sm2_config_read_platform(&attr);
   if (ret < 0) return ret;
-  LL = ret;
+  memcpy(RDATA, &attr, sizeof(attr));
+  LL = sizeof(attr);
   return 0;
 }
 
@@ -1015,7 +1053,7 @@ int ctap_write_sm2_config(const CAPDU *capdu, RAPDU *rapdu) {
   CTAP_sm2_attr attr;
   memcpy(&attr, DATA, sizeof(attr));
   if (!ctap_sm2_algo_id_valid(attr.algo_id)) EXCEPT(SW_WRONG_DATA);
-  const int ret = write_attr(CTAP_CERT_FILE, SM2_ATTR, &attr, sizeof(attr));
+  const int ret = ctap_platform_sm2_config_write(&attr, sizeof(attr));
   if (ret < 0) return ret;
   ctap_sm2_attr = attr;
   return 0;

--- a/applets/ctap/ctap.c
+++ b/applets/ctap/ctap.c
@@ -98,30 +98,6 @@ static ctap_src_t current_cmd_src;
 // SM2 attr
 CTAP_sm2_attr ctap_sm2_attr;
 
-__weak int ctap_platform_sm2_config_read(void *cfg, size_t len) {
-  UNUSED(cfg);
-  UNUSED(len);
-  return -1;
-}
-
-__weak int ctap_platform_sm2_config_write(const void *cfg, size_t len) {
-  UNUSED(cfg);
-  UNUSED(len);
-  return -1;
-}
-
-__weak int ctap_platform_persistent_config_read(void *cfg, size_t len) {
-  UNUSED(cfg);
-  UNUSED(len);
-  return -1;
-}
-
-__weak int ctap_platform_persistent_config_write(const void *cfg, size_t len) {
-  UNUSED(cfg);
-  UNUSED(len);
-  return -1;
-}
-
 static void ctap_sm2_config_set_default(void) {
   ctap_sm2_attr.curve_id = 9;  // An unused one. See https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves
   ctap_sm2_attr.algo_id = -54; // An unused one. See https://www.iana.org/assignments/cose/cose.xhtml#algorithms

--- a/applets/ndef/ndef.c
+++ b/applets/ndef/ndef.c
@@ -55,7 +55,7 @@ void ndef_poweroff(void) {
   ndef_write_reset();
 }
 
-int ndef_get_read_only(void) { return CC_W == 0xFF ? 1 : 0; }
+int ndef_is_read_only(void) { return CC_W == 0xFF ? 1 : 0; }
 
 int ndef_toggle_read_only(const CAPDU *capdu, RAPDU *rapdu) {
   switch (P1) {

--- a/applets/oath/oath.c
+++ b/applets/oath/oath.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <apdu.h>
 #include <crypto-util.h>
+#include <device-config.h>
 #include <device.h>
 #include <fs.h>
 #include <hmac.h>
@@ -632,7 +633,7 @@ static int oath_yk_api_req(const CAPDU *capdu, RAPDU *rapdu) {
   switch (P1) {
   case YK_CMD_GET_SERIAL:
     if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
-    fill_sn(RDATA);
+    device_config_fill_serial(RDATA);
     LL = 4;
     return 0;
 

--- a/applets/openpgp/openpgp.c
+++ b/applets/openpgp/openpgp.c
@@ -3,6 +3,7 @@
 #include "key.h"
 #include <applet-scratch.h>
 #include <common.h>
+#include <device-config.h>
 #include <device.h>
 #include <ecc.h>
 #include <key.h>
@@ -494,7 +495,7 @@ static int openpgp_get_data(const CAPDU *capdu, RAPDU *rapdu) {
   switch (tag) {
   case TAG_AID:
     memcpy(RDATA, aid, sizeof(aid));
-    fill_sn(RDATA + 10);
+    device_config_fill_serial(RDATA + 10);
     LL = sizeof(aid);
     break;
 
@@ -549,7 +550,7 @@ static int openpgp_get_data(const CAPDU *capdu, RAPDU *rapdu) {
     RDATA[off++] = TAG_AID;
     RDATA[off++] = sizeof(aid);
     memcpy(RDATA + off, aid, sizeof(aid));
-    fill_sn(RDATA + off + 10);
+    device_config_fill_serial(RDATA + off + 10);
     off += sizeof(aid);
 
     RDATA[off++] = HI(TAG_HISTORICAL_BYTES);

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -456,8 +456,8 @@ static bool piv_littlefs_state_present(void) {
   return ck_read_key_metadata(CARD_ADMIN_KEY_PATH, &meta) >= 0 &&
          read_attr(CARD_ADMIN_KEY_PATH, TAG_PIN_KEY_DEFAULT, &default_value, sizeof(default_value)) ==
              sizeof(default_value) &&
-         get_file_size(CHUID_PATH) >= 0 && get_file_size(CCC_PATH) >= 0 &&
-         pin_get_size(&pin) == 8 && pin_get_retries(&pin) >= 0 && pin_get_default_retries(&pin) >= 0 &&
+         get_file_size(CHUID_PATH) >= 0 && get_file_size(CCC_PATH) >= 0 && pin_get_size(&pin) == 8 &&
+         pin_get_retries(&pin) >= 0 && pin_get_default_retries(&pin) >= 0 &&
          read_attr(pin.path, TAG_PIN_KEY_DEFAULT, &default_value, sizeof(default_value)) == sizeof(default_value) &&
          pin_get_size(&puk) == 8 && pin_get_retries(&puk) >= 0 && pin_get_default_retries(&puk) >= 0 &&
          read_attr(puk.path, TAG_PIN_KEY_DEFAULT, &default_value, sizeof(default_value)) == sizeof(default_value);
@@ -796,9 +796,12 @@ void piv_poweroff(void) {
 
 int piv_install(const uint8_t reset) {
   piv_poweroff();
+  piv_algorithm_extension_config_t preserved_alg_ext_cfg;
+  const bool has_alg_ext_cfg = piv_algorithm_extension_config_load(&preserved_alg_ext_cfg) == 0;
   // Platform alg-ext config is the install completion marker. If it is missing
   // or invalid, rebuild PIV state.
-  if (!reset && piv_algorithm_extension_config_load(&alg_ext_cfg) == 0 && piv_littlefs_state_present()) {
+  if (!reset && has_alg_ext_cfg && piv_littlefs_state_present()) {
+    alg_ext_cfg = preserved_alg_ext_cfg;
     return 0;
   }
   if (piv_clear_file_do_storage() < 0) return -1;
@@ -841,9 +844,15 @@ int piv_install(const uint8_t reset) {
   if (pin_create(&puk, DEFAULT_PUK, 8, 3) < 0) return -1;
   if (write_attr(puk.path, TAG_PIN_KEY_DEFAULT, &tmp, sizeof(tmp)) < 0) return -1;
 
-  // Algorithm extensions. This must remain the last persistent write in the
-  // install path because successful readback is used as the initialized marker.
-  piv_algorithm_extension_config_set_default();
+  // Algorithm extensions must remain the last persistent write because
+  // successful readback is used as the initialized marker. Preserve valid
+  // platform config across a PIV reset so admin-selected algorithm IDs survive
+  // provisioning tools that reset the applet before use.
+  if (has_alg_ext_cfg) {
+    alg_ext_cfg = preserved_alg_ext_cfg;
+  } else {
+    piv_algorithm_extension_config_set_default();
+  }
   if (piv_platform_algorithm_extension_config_write(&alg_ext_cfg) < 0) return -1;
 
   return 0;

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -251,16 +251,6 @@ static const struct {
     {KEY_MANAGEMENT_83_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
 };
 
-__weak int piv_platform_algorithm_extension_config_read(piv_algorithm_extension_config_t *cfg) {
-  UNUSED(cfg);
-  return -1;
-}
-
-__weak int piv_platform_algorithm_extension_config_write(const piv_algorithm_extension_config_t *cfg) {
-  UNUSED(cfg);
-  return -1;
-}
-
 static bool piv_algorithm_extension_config_valid(const piv_algorithm_extension_config_t *cfg) {
   return cfg->enabled <= 1;
 }

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -4,6 +4,7 @@
 #include <common.h>
 #include <crypto-util.h>
 #include <des.h>
+#include <device-config.h>
 #include <device.h>
 #include <ecc.h>
 #include <key.h>
@@ -48,7 +49,6 @@
 
 // alg
 // clang-format off
-#define ALGORITHM_EXT_CONFIG_PATH  "piv-alg"
 #define ALG_DEFAULT   0x00
 #define ALG_TDEA_3KEY 0x03
 #define ALG_RSA_2048  0x07
@@ -238,6 +238,38 @@ enum {
 static pin_t pin = {.min_length = 8, .max_length = 8, .is_validated = 0, .path = "piv-pin"};
 static pin_t puk = {.min_length = 8, .max_length = 8, .is_validated = 0, .path = "piv-puk"};
 
+static const struct {
+  const char *path;
+  key_usage_t usage;
+  pin_policy_t pin_policy;
+} key_specs[] = {
+    {AUTH_KEY_PATH, SIGN, PIN_POLICY_ONCE},
+    {SIG_KEY_PATH, SIGN, PIN_POLICY_ONCE},
+    {KEY_MANAGEMENT_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
+    {CARD_AUTH_KEY_PATH, SIGN, PIN_POLICY_NEVER},
+    {KEY_MANAGEMENT_82_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
+    {KEY_MANAGEMENT_83_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
+};
+
+__weak int piv_platform_algorithm_extension_config_read(piv_algorithm_extension_config_t *cfg) {
+  UNUSED(cfg);
+  return -1;
+}
+
+__weak int piv_platform_algorithm_extension_config_write(const piv_algorithm_extension_config_t *cfg) {
+  UNUSED(cfg);
+  return -1;
+}
+
+static bool piv_algorithm_extension_config_valid(const piv_algorithm_extension_config_t *cfg) {
+  return cfg->enabled <= 1;
+}
+
+static int piv_algorithm_extension_config_load(piv_algorithm_extension_config_t *cfg) {
+  if (piv_platform_algorithm_extension_config_read(cfg) < 0) return -1;
+  return piv_algorithm_extension_config_valid(cfg) ? 0 : -1;
+}
+
 static void authenticate_reset(void) {
   auth_ctx[OFFSET_AUTH_STATE] = AUTH_STATE_NONE;
   memset(auth_ctx + OFFSET_AUTH_CHALLENGE, 0, LENGTH_CHALLENGE);
@@ -413,6 +445,22 @@ static int piv_clear_inline_do_storage(void) {
     if (piv_clear_attr_if_present(CARD_ADMIN_KEY_PATH, attrs[i]) < 0) return -1;
   }
   return piv_remove_file_if_present(PIV_DO_META_PATH);
+}
+
+static bool piv_littlefs_state_present(void) {
+  key_meta_t meta;
+  uint8_t default_value;
+  for (size_t i = 0; i < sizeof(key_specs) / sizeof(key_specs[0]); ++i) {
+    if (ck_read_key_metadata(key_specs[i].path, &meta) < 0) return false;
+  }
+  return ck_read_key_metadata(CARD_ADMIN_KEY_PATH, &meta) >= 0 &&
+         read_attr(CARD_ADMIN_KEY_PATH, TAG_PIN_KEY_DEFAULT, &default_value, sizeof(default_value)) ==
+             sizeof(default_value) &&
+         get_file_size(CHUID_PATH) >= 0 && get_file_size(CCC_PATH) >= 0 &&
+         pin_get_size(&pin) == 8 && pin_get_retries(&pin) >= 0 && pin_get_default_retries(&pin) >= 0 &&
+         read_attr(pin.path, TAG_PIN_KEY_DEFAULT, &default_value, sizeof(default_value)) == sizeof(default_value) &&
+         pin_get_size(&puk) == 8 && pin_get_retries(&puk) >= 0 && pin_get_default_retries(&puk) >= 0 &&
+         read_attr(puk.path, TAG_PIN_KEY_DEFAULT, &default_value, sizeof(default_value)) == sizeof(default_value);
 }
 
 static key_type_t algo_id_to_key_type(const uint8_t id) {
@@ -723,6 +771,16 @@ static void piv_auth_reset(void) {
   piv_auth_len = 0;
 }
 
+static void piv_algorithm_extension_config_set_default(void) {
+  alg_ext_cfg.enabled = 1;
+  alg_ext_cfg.ed25519 = ALG_ED25519_DEFAULT;
+  alg_ext_cfg.rsa3072 = ALG_RSA_3072_DEFAULT;
+  alg_ext_cfg.rsa4096 = ALG_RSA_4096_DEFAULT;
+  alg_ext_cfg.x25519 = ALG_X25519_DEFAULT;
+  alg_ext_cfg.secp256k1 = ALG_SECP256K1_DEFAULT;
+  alg_ext_cfg.sm2 = ALG_SM2_DEFAULT;
+}
+
 void piv_poweroff(void) {
   piv_state = PIV_STATE_OTHER;
   in_admin_status = 0;
@@ -738,24 +796,12 @@ void piv_poweroff(void) {
 
 int piv_install(const uint8_t reset) {
   piv_poweroff();
-  if (!reset && get_file_size(ALGORITHM_EXT_CONFIG_PATH) >= 0) {
-    if (read_file(ALGORITHM_EXT_CONFIG_PATH, &alg_ext_cfg, 0, sizeof(alg_ext_cfg)) < 0) return -1;
+  // Platform alg-ext config is the install completion marker. If it is missing
+  // or invalid, rebuild PIV state.
+  if (!reset && piv_algorithm_extension_config_load(&alg_ext_cfg) == 0 && piv_littlefs_state_present()) {
     return 0;
   }
-  if (reset && piv_clear_file_do_storage() < 0) return -1;
-
-  static const struct {
-    const char *path;
-    key_usage_t usage;
-    pin_policy_t pin_policy;
-  } key_specs[] = {
-      {AUTH_KEY_PATH, SIGN, PIN_POLICY_ONCE},
-      {SIG_KEY_PATH, SIGN, PIN_POLICY_ONCE},
-      {KEY_MANAGEMENT_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
-      {CARD_AUTH_KEY_PATH, SIGN, PIN_POLICY_NEVER},
-      {KEY_MANAGEMENT_82_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
-      {KEY_MANAGEMENT_83_KEY_PATH, KEY_AGREEMENT, PIN_POLICY_ONCE},
-  };
+  if (piv_clear_file_do_storage() < 0) return -1;
 
   // Default objects. Optional DO files are created lazily on PUT DATA so empty
   // retired cert and biometric objects do not consume LittleFS metadata blocks.
@@ -785,7 +831,7 @@ int piv_install(const uint8_t reset) {
                                  .touch_policy = TOUCH_POLICY_NEVER}};
   memcpy(admin_key.data, DEFAULT_MGMT_KEY, 24);
   if (ck_write_key(CARD_ADMIN_KEY_PATH, &admin_key) < 0) return -1;
-  if (reset && piv_clear_inline_do_storage() < 0) return -1;
+  if (piv_clear_inline_do_storage() < 0) return -1;
   const uint8_t tmp = 0x01;
   if (write_attr(CARD_ADMIN_KEY_PATH, TAG_PIN_KEY_DEFAULT, &tmp, sizeof(tmp)) < 0) return -1;
 
@@ -795,16 +841,10 @@ int piv_install(const uint8_t reset) {
   if (pin_create(&puk, DEFAULT_PUK, 8, 3) < 0) return -1;
   if (write_attr(puk.path, TAG_PIN_KEY_DEFAULT, &tmp, sizeof(tmp)) < 0) return -1;
 
-  if (get_file_size(ALGORITHM_EXT_CONFIG_PATH) == sizeof(alg_ext_cfg)) return 0;
-  // Algorithm extensions
-  alg_ext_cfg.enabled = 1;
-  alg_ext_cfg.ed25519 = ALG_ED25519_DEFAULT;
-  alg_ext_cfg.rsa3072 = ALG_RSA_3072_DEFAULT;
-  alg_ext_cfg.rsa4096 = ALG_RSA_4096_DEFAULT;
-  alg_ext_cfg.x25519 = ALG_X25519_DEFAULT;
-  alg_ext_cfg.secp256k1 = ALG_SECP256K1_DEFAULT;
-  alg_ext_cfg.sm2 = ALG_SM2_DEFAULT;
-  if (write_file(ALGORITHM_EXT_CONFIG_PATH, &alg_ext_cfg, 0, sizeof(alg_ext_cfg), 1) < 0) return -1;
+  // Algorithm extensions. This must remain the last persistent write in the
+  // install path because successful readback is used as the initialized marker.
+  piv_algorithm_extension_config_set_default();
+  if (piv_platform_algorithm_extension_config_write(&alg_ext_cfg) < 0) return -1;
 
   return 0;
 }
@@ -1511,8 +1551,7 @@ static int piv_reset(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x00 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
   if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
   if (pin_get_retries(&pin) > 0 || pin_get_retries(&puk) > 0) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
-  piv_install(1);
-  return 0;
+  return piv_install(1);
 }
 
 static int piv_import_asymmetric_key(const CAPDU *capdu, RAPDU *rapdu) {
@@ -1713,7 +1752,7 @@ static int piv_get_version(const CAPDU *capdu, RAPDU *rapdu) {
 static int piv_get_serial(const CAPDU *capdu, RAPDU *rapdu) {
   if (P1 != 0x00 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
   if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
-  fill_sn(RDATA);
+  device_config_fill_serial(RDATA);
   LL = 4;
   return 0;
 }
@@ -1727,15 +1766,20 @@ static int piv_algorithm_extension(const CAPDU *capdu, RAPDU *rapdu) {
   if (P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
 
   if (P1 == 0x01) {
-    if (read_file(ALGORITHM_EXT_CONFIG_PATH, RDATA, 0, sizeof(alg_ext_cfg)) < 0) return -1;
-    LL = sizeof(alg_ext_cfg);
+    piv_algorithm_extension_config_t cfg;
+    if (piv_algorithm_extension_config_load(&cfg) < 0) return -1;
+    memcpy(RDATA, &cfg, sizeof(cfg));
+    LL = sizeof(cfg);
   } else {
     if (LC != sizeof(alg_ext_cfg)) EXCEPT(SW_WRONG_LENGTH);
-    if (DATA[0] != 0 && DATA[0] != 1) EXCEPT(SW_WRONG_DATA);
-    // We trust the rest data because no dangerous result will be caused even if the IDs are not unique.
-    if (write_file(ALGORITHM_EXT_CONFIG_PATH, DATA, 0, sizeof(alg_ext_cfg), 1) < 0) return -1;
+    piv_algorithm_extension_config_t cfg;
+    memcpy(&cfg, DATA, sizeof(cfg));
+    // Algorithm IDs may intentionally overlap; only the enable flag has a
+    // constrained domain.
+    if (!piv_algorithm_extension_config_valid(&cfg)) EXCEPT(SW_WRONG_DATA);
+    if (piv_platform_algorithm_extension_config_write(&cfg) < 0) return -1;
     // Effective immediately
-    memcpy(&alg_ext_cfg, DATA, sizeof(alg_ext_cfg));
+    alg_ext_cfg = cfg;
   }
 
   return 0;

--- a/include/admin.h
+++ b/include/admin.h
@@ -3,6 +3,8 @@
 #define CANOKEY_CORE_ADMIN_ADMIN_H_
 
 #include <apdu.h>
+#include <stdbool.h>
+#include <stdint.h>
 
 #define ADMIN_INS_WRITE_FIDO_PRIVATE_KEY 0x01
 #define ADMIN_INS_WRITE_FIDO_CERT 0x02
@@ -26,9 +28,42 @@
 #define ADMIN_INS_READ_CONFIG 0x42
 #define ADMIN_INS_READ_PASS_CONFIG 0x43
 #define ADMIN_INS_WRITE_PASS_CONFIG 0x44
+
+/**
+ * @brief KBD keymap admin APDUs.
+ *
+ * The keymap is a fixed 128-entry ASCII table. Entry N maps ASCII code N to
+ * two bytes: {HID modifier, HID usage}. A stored table is authoritative for
+ * KBDHID output; usage 0 means "skip this character" instead of falling back
+ * to the built-in QWERTY map.
+ *
+ * ADMIN_INS_WRITE_KBD_KEYMAP:
+ *   P1 = 0x00
+ *   P2 = host-defined layout id
+ *   Lc = ADMIN_KBD_KEYMAP_LENGTH
+ *   Data = 128 consecutive {modifier, usage} entries
+ *
+ * ADMIN_INS_READ_KBD_KEYMAP:
+ *   P1 = 0x00
+ *   P2 = ADMIN_P2_KBD_READ_LAYOUT_ID: Le >= 1, returns one layout-id byte
+ *   P2 = ADMIN_P2_KBD_READ_KEYMAP: Le >= ADMIN_KBD_KEYMAP_LENGTH, returns the
+ *        128-entry {modifier, usage} table without the layout id
+ *
+ * ADMIN_INS_CLEAR_KBD_KEYMAP:
+ *   P1 = 0x00, P2 = 0x00, Lc = 0
+ */
+#define ADMIN_INS_WRITE_KBD_KEYMAP 0x45
+#define ADMIN_INS_READ_KBD_KEYMAP 0x46
+#define ADMIN_INS_CLEAR_KBD_KEYMAP 0x47
 #define ADMIN_INS_FACTORY_RESET 0x50
 #define ADMIN_INS_SELECT 0xA4
 #define ADMIN_INS_VENDOR_SPECIFIC 0xFF
+
+#define ADMIN_KBD_ASCII_COUNT 128
+#define ADMIN_KBD_KEYMAP_ENTRY_SIZE 2
+#define ADMIN_KBD_KEYMAP_LENGTH (ADMIN_KBD_ASCII_COUNT * ADMIN_KBD_KEYMAP_ENTRY_SIZE)
+#define ADMIN_P2_KBD_READ_LAYOUT_ID 0x00
+#define ADMIN_P2_KBD_READ_KEYMAP 0x01
 
 #define ADMIN_P1_CFG_LED_ON 0x01
 #define ADMIN_P1_CFG_NDEF 0x04
@@ -49,8 +84,22 @@ int admin_vendor_hw_variant(const CAPDU *capdu, RAPDU *rapdu);
 int admin_vendor_hw_sn(const CAPDU *capdu, RAPDU *rapdu);
 int admin_vendor_nfc_enable(const CAPDU *capdu, RAPDU *rapdu, bool pin_validated);
 
-uint8_t cfg_is_led_normally_on(void);
-uint8_t cfg_is_ndef_enable(void);
-uint8_t cfg_is_webusb_landing_enable(void);
+/*
+ * Platform persistence hooks.
+ *
+ * Core owns the config semantics, while the platform owns the physical storage layout.
+ */
+int admin_platform_device_config_read(admin_device_config_t *cfg);
+int admin_platform_device_config_write(const admin_device_config_t *cfg);
+int admin_platform_serial_read(uint8_t *buf);
+int admin_platform_serial_write_once(const uint8_t *buf);
+/*
+ * KBD keymap admin commands use a 128-entry ASCII table. Each entry is
+ * {modifier, HID usage}; a valid platform table is authoritative, and usage 0
+ * means the character is intentionally skipped.
+ */
+int admin_platform_kbd_keymap_write(uint8_t layout_id, const uint8_t *keymap, uint16_t len);
+int admin_platform_kbd_keymap_read(uint8_t *layout_id, uint8_t *keymap, uint16_t len);
+int admin_platform_kbd_keymap_clear(void);
 
 #endif // CANOKEY_CORE_ADMIN_ADMIN_H_

--- a/include/admin.h
+++ b/include/admin.h
@@ -85,9 +85,7 @@ int admin_vendor_hw_sn(const CAPDU *capdu, RAPDU *rapdu);
 int admin_vendor_nfc_enable(const CAPDU *capdu, RAPDU *rapdu, bool pin_validated);
 
 /*
- * Platform persistence hooks.
- *
- * Core owns the config semantics, while the platform owns the physical storage layout.
+ * Core config accessors backed by the platform config page.
  */
 int admin_platform_device_config_read(admin_device_config_t *cfg);
 int admin_platform_device_config_write(const admin_device_config_t *cfg);

--- a/include/applets.h
+++ b/include/applets.h
@@ -2,7 +2,7 @@
 #ifndef APPLETS_H_
 #define APPLETS_H_
 
-void applets_install(void);
+int applets_install(void);
 void applets_poweroff(void);
 
 #endif // APPLETS_H_

--- a/include/common.h
+++ b/include/common.h
@@ -92,10 +92,4 @@
 // get length of tlv with bounds checking
 uint16_t tlv_get_length_safe(const uint8_t *data, const size_t len, int *fail, size_t *length_size);
 
-/**
- * Fill a 4-byte serial number
- * @param buf buffer to be filled
- */
-void fill_sn(uint8_t *buf);
-
 #endif // CANOKEY_CORE_INCLUDE_COMMON_H

--- a/include/ctap.h
+++ b/include/ctap.h
@@ -34,6 +34,14 @@ int ctap_install_private_key(const CAPDU *capdu, RAPDU *rapdu);
 int ctap_install_cert(const CAPDU *capdu, RAPDU *rapdu);
 int ctap_read_sm2_config(const CAPDU *capdu, RAPDU *rapdu);
 int ctap_write_sm2_config(const CAPDU *capdu, RAPDU *rapdu);
+
+// Platform storage for the vendor SM2 COSE identifiers.
+int ctap_platform_sm2_config_read(void *cfg, size_t len);
+int ctap_platform_sm2_config_write(const void *cfg, size_t len);
+// Platform storage for CTAP 2.3 persistent options such as min PIN length and alwaysUV.
+int ctap_platform_persistent_config_read(void *cfg, size_t len);
+int ctap_platform_persistent_config_write(const void *cfg, size_t len);
+
 int ctap_process_cbor_with_src(uint8_t *req, size_t req_len, uint8_t *resp, size_t *resp_len, ctap_src_t src);
 // Returns 1 on success with `*source` populated, or -1 on failure.
 int ctap_process_cbor_stream_source_with_src(const ctap_req_src_t *req_src, uint8_t *scratch, size_t scratch_len,

--- a/include/device-config.h
+++ b/include/device-config.h
@@ -11,6 +11,10 @@
 uint8_t device_config_is_led_normally_on(void);
 uint8_t device_config_is_ndef_enabled(void);
 uint8_t device_config_is_webusb_landing_enabled(void);
+uint8_t device_config_is_initialized(void);
+int device_config_mark_initialized(void);
+uint8_t device_config_is_nfc_enabled(void);
+int device_config_set_nfc_enabled(uint8_t enabled);
 
 /*
  * Fill the 4-byte user-visible serial number. Missing platform serial storage

--- a/include/device-config.h
+++ b/include/device-config.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef CANOKEY_CORE_INCLUDE_DEVICE_CONFIG_H_
+#define CANOKEY_CORE_INCLUDE_DEVICE_CONFIG_H_
+
+#include <stdint.h>
+
+/*
+ * Runtime device-config readers used outside the admin applet. Writers and
+ * platform persistence hooks stay in admin.h because they are admin commands.
+ */
+uint8_t device_config_is_led_normally_on(void);
+uint8_t device_config_is_ndef_enabled(void);
+uint8_t device_config_is_webusb_landing_enabled(void);
+
+/*
+ * Fill the 4-byte user-visible serial number. Missing platform serial storage
+ * returns all zeros.
+ */
+void device_config_fill_serial(uint8_t *buf);
+
+#endif // CANOKEY_CORE_INCLUDE_DEVICE_CONFIG_H_

--- a/include/device.h
+++ b/include/device.h
@@ -2,6 +2,8 @@
 #ifndef _DEVICE_H_
 #define _DEVICE_H_
 
+#include <stdbool.h>
+
 #include "common.h"
 #include "nfc.h"
 

--- a/include/ndef.h
+++ b/include/ndef.h
@@ -14,7 +14,7 @@ void ndef_poweroff(void);
 int ndef_install(uint8_t reset);
 int ndef_process_apdu(const CAPDU *capdu, RAPDU *rapdu);
 int ndef_process_apdu_message(RAPDU_CHAINING *rapdu_chaining, CAPDU *capdu, RAPDU *rapdu);
-int ndef_get_read_only(void);
+int ndef_is_read_only(void);
 int ndef_toggle_read_only(const CAPDU *capdu, RAPDU *rapdu);
 #else
 static inline void ndef_poweroff(void) {}
@@ -33,7 +33,7 @@ static inline int ndef_process_apdu_message(RAPDU_CHAINING *rapdu_chaining, CAPD
   (void)rapdu;
   return 0;
 }
-static inline int ndef_get_read_only(void) { return 0; }
+static inline int ndef_is_read_only(void) { return 0; }
 static inline int ndef_toggle_read_only(const CAPDU *capdu, RAPDU *rapdu) {
   (void)capdu;
   (void)rapdu;

--- a/include/piv.h
+++ b/include/piv.h
@@ -43,4 +43,11 @@ void piv_poweroff(void);
 int piv_process_apdu(const CAPDU *capdu, RAPDU *rapdu);
 int piv_process_apdu_message(RAPDU_CHAINING *rapdu_chaining, CAPDU *capdu, RAPDU *rapdu);
 
+/*
+ * Platform storage for configurable PIV algorithm IDs. Core uses a valid
+ * platform record as the PIV install completion marker.
+ */
+int piv_platform_algorithm_extension_config_read(piv_algorithm_extension_config_t *cfg);
+int piv_platform_algorithm_extension_config_write(const piv_algorithm_extension_config_t *cfg);
+
 #endif // CANOKEY_CORE_INCLUDE_PIV_H_

--- a/include/platform-config.h
+++ b/include/platform-config.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef CANOKEY_CORE_INCLUDE_PLATFORM_CONFIG_H_
+#define CANOKEY_CORE_INCLUDE_PLATFORM_CONFIG_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define PLATFORM_CONFIG_PAGE_SIZE 512u
+
+/*
+ * Platform storage hooks for the core-owned config page.
+ *
+ * Reads may address any byte range in the page. Writes are always full-page:
+ * platform_config_page_write() is called only with PLATFORM_CONFIG_PAGE_SIZE
+ * bytes, and ports backed by erase-block flash should reject partial writes.
+ */
+int platform_config_page_read(size_t off, void *buf, size_t len);
+int platform_config_page_write(const void *page, size_t len);
+
+#endif // CANOKEY_CORE_INCLUDE_PLATFORM_CONFIG_H_

--- a/interfaces/USB/class/kbdhid/kbdhid.c
+++ b/interfaces/USB/class/kbdhid/kbdhid.c
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <admin.h>
 #include <common.h>
 #include <device.h>
 #include <kbdhid.h>
@@ -19,90 +18,158 @@ static char key_sequence[PASS_MAX_PASSWORD_LENGTH + 2]; // one for enter and one
 static uint8_t key_seq_position;
 static keyboard_report_t report;
 
-static uint8_t ascii2keycode(char ch) {
+__weak bool kbdhid_platform_translate_ascii(uint8_t ch, uint8_t *modifier, uint8_t *usage) {
+  UNUSED(ch);
+  UNUSED(modifier);
+  UNUSED(usage);
+  return false;
+}
+
+static bool ascii2key_report(char ch, uint8_t *modifier, uint8_t *usage) {
+  // Platforms can provide a layout-specific map. If they do, the returned HID
+  // report is authoritative; the built-in table is only the QWERTY fallback.
+  if (kbdhid_platform_translate_ascii((uint8_t)ch, modifier, usage)) return true;
+
   const uint8_t shift = 0x80; // Shift key flag
+  uint8_t keycode;
 
   // digits and lowercase letters
-  if ('1' <= ch && ch <= '9') return 30 + ch - '1';
-  if ('0' == ch) return 39;
-  if ('a' <= ch && ch <= 'z') return 4 + ch - 'a';
+  if ('1' <= ch && ch <= '9') {
+    keycode = 30 + ch - '1';
+    goto done;
+  }
+  if ('0' == ch) {
+    keycode = 39;
+    goto done;
+  }
+  if ('a' <= ch && ch <= 'z') {
+    keycode = 4 + ch - 'a';
+    goto done;
+  }
 
   // uppercase letters
-  if ('A' <= ch && ch <= 'Z') return (4 + ch - 'A') | shift;
+  if ('A' <= ch && ch <= 'Z') {
+    keycode = (4 + ch - 'A') | shift;
+    goto done;
+  }
 
   // symbols and special characters
   switch (ch) {
   case 13:
-    return 0x28; // \r
+    keycode = 0x28; // \r
+    break;
   case 32:
-    return 0x2C; // space
+    keycode = 0x2C; // space
+    break;
   case 33:
-    return 0x1E | shift; // !
+    keycode = 0x1E | shift; // !
+    break;
   case 34:
-    return 0x34 | shift; // "
+    keycode = 0x34 | shift; // "
+    break;
   case 35:
-    return 0x20 | shift; // #
+    keycode = 0x20 | shift; // #
+    break;
   case 36:
-    return 0x21 | shift; // $
+    keycode = 0x21 | shift; // $
+    break;
   case 37:
-    return 0x22 | shift; // %
+    keycode = 0x22 | shift; // %
+    break;
   case 38:
-    return 0x24 | shift; // &
+    keycode = 0x24 | shift; // &
+    break;
   case 39:
-    return 0x34; // '
+    keycode = 0x34; // '
+    break;
   case 40:
-    return 0x26 | shift; // (
+    keycode = 0x26 | shift; // (
+    break;
   case 41:
-    return 0x27 | shift; // )
+    keycode = 0x27 | shift; // )
+    break;
   case 42:
-    return 0x25 | shift; // *
+    keycode = 0x25 | shift; // *
+    break;
   case 43:
-    return 0x2E | shift; // +
+    keycode = 0x2E | shift; // +
+    break;
   case 44:
-    return 0x36; // ,
+    keycode = 0x36; // ,
+    break;
   case 45:
-    return 0x2D; // -
+    keycode = 0x2D; // -
+    break;
   case 46:
-    return 0x37; // .
+    keycode = 0x37; // .
+    break;
   case 47:
-    return 0x38; // /
+    keycode = 0x38; // /
+    break;
   case 58:
-    return 0x33 | shift; // :
+    keycode = 0x33 | shift; // :
+    break;
   case 59:
-    return 0x33; // ;
+    keycode = 0x33; // ;
+    break;
   case 60:
-    return 0x36 | shift; // <
+    keycode = 0x36 | shift; // <
+    break;
   case 61:
-    return 0x2E; // =
+    keycode = 0x2E; // =
+    break;
   case 62:
-    return 0x37 | shift; // >
+    keycode = 0x37 | shift; // >
+    break;
   case 63:
-    return 0x38 | shift; // ?
+    keycode = 0x38 | shift; // ?
+    break;
   case 64:
-    return 0x1F | shift; // @
+    keycode = 0x1F | shift; // @
+    break;
   case 91:
-    return 0x2F; // [
+    keycode = 0x2F; // [
+    break;
   case 92:
-    return 0x31; // "\"
+    keycode = 0x31; // "\"
+    break;
   case 93:
-    return 0x30; // ]
+    keycode = 0x30; // ]
+    break;
   case 94:
-    return 0x23 | shift; // ^
+    keycode = 0x23 | shift; // ^
+    break;
   case 95:
-    return 0x2D | shift; // _
+    keycode = 0x2D | shift; // _
+    break;
   case 96:
-    return 0x35; // `
+    keycode = 0x35; // `
+    break;
   case 123:
-    return 0x2F | shift; // {
+    keycode = 0x2F | shift; // {
+    break;
   case 124:
-    return 0x31 | shift; // |
+    keycode = 0x31 | shift; // |
+    break;
   case 125:
-    return 0x30 | shift; // }
+    keycode = 0x30 | shift; // }
+    break;
   case 126:
-    return 0x35 | shift; // ~
+    keycode = 0x35 | shift; // ~
+    break;
   default:
-    return 0; // undefined
+    return false; // undefined
   }
+
+done:
+  if (keycode & shift) {
+    *modifier = 0x02; // Shift key
+    keycode &= ~shift;
+  } else {
+    *modifier = 0;
+  }
+  *usage = keycode;
+  return true;
 }
 
 static void KBDHID_TypeKeySeq(void) {
@@ -121,14 +188,16 @@ static void KBDHID_TypeKeySeq(void) {
         // Emulate the key press
         USBD_KBDHID_SendReport(&usb_device, (uint8_t *)&report, 2);
       } else {
-        uint8_t keycode = ascii2keycode(key_sequence[key_seq_position]);
-        if (keycode & 0x80) {     // Check for shift flag
-          report.modifier = 0x02; // Shift key
-          keycode &= 0x7F;        // Clear shift flag
-        } else {
-          report.modifier = 0; // No modifier key
+        if (!ascii2key_report(key_sequence[key_seq_position], &report.modifier, &report.keycode[0])) {
+          key_seq_position++;
+          state = KBDHID_KeyUp;
+          break;
         }
-        report.keycode[0] = keycode;
+        if (report.keycode[0] == 0) {
+          key_seq_position++;
+          state = KBDHID_KeyUp;
+          break;
+        }
         report.id = 1;
         // Emulate the key press
         USBD_KBDHID_SendReport(&usb_device, (uint8_t *)&report, sizeof(report));

--- a/interfaces/USB/class/kbdhid/kbdhid.c
+++ b/interfaces/USB/class/kbdhid/kbdhid.c
@@ -18,13 +18,6 @@ static char key_sequence[PASS_MAX_PASSWORD_LENGTH + 2]; // one for enter and one
 static uint8_t key_seq_position;
 static keyboard_report_t report;
 
-__weak bool kbdhid_platform_translate_ascii(uint8_t ch, uint8_t *modifier, uint8_t *usage) {
-  UNUSED(ch);
-  UNUSED(modifier);
-  UNUSED(usage);
-  return false;
-}
-
 static bool ascii2key_report(char ch, uint8_t *modifier, uint8_t *usage) {
   // Platforms can provide a layout-specific map. If they do, the returned HID
   // report is authoritative; the built-in table is only the QWERTY fallback.

--- a/interfaces/USB/class/kbdhid/kbdhid.h
+++ b/interfaces/USB/class/kbdhid/kbdhid.h
@@ -3,9 +3,18 @@
 #define __KBDHID_H_INCLUDED__
 
 #include <common.h>
+#include <stdbool.h>
 
 uint8_t KBDHID_Init(void);
 uint8_t KBDHID_Loop(void);
 void KBDHID_Eject(void);
+
+/*
+ * Optional platform ASCII translation override.
+ *
+ * Return true after filling a HID modifier and usage. Return false to let
+ * KBDHID use its built-in QWERTY mapping.
+ */
+bool kbdhid_platform_translate_ascii(uint8_t ch, uint8_t *modifier, uint8_t *usage);
 
 #endif // __KBDHID_H_INCLUDED__

--- a/interfaces/USB/device/usbd_desc.c
+++ b/interfaces/USB/device/usbd_desc.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-#include <admin.h>
+#include <device-config.h>
 #include <usbd_canokey.h>
 #include <usbd_ccid.h>
 #include <usbd_core.h>
@@ -467,7 +467,7 @@ const uint8_t *USBD_SerialStrDescriptor(USBD_SpeedTypeDef speed __attribute__((u
     *length = 0;
     return NULL;
   }
-  fill_sn(sn);
+  device_config_fill_serial(sn);
   bytes_to_hex(sn, sizeof(sn), sn_str);
   USBD_GetString((uint8_t *)sn_str, shared_io_buffer, length);
   return shared_io_buffer;
@@ -484,7 +484,7 @@ const uint8_t *USBD_BOSDescriptor(USBD_SpeedTypeDef speed __attribute__((unused)
   }
   *length = sizeof(USBD_FS_BOSDesc);
   memcpy(shared_io_buffer, USBD_FS_BOSDesc, sizeof(USBD_FS_BOSDesc)); // use shared_io_buffer to store this descriptor
-  shared_io_buffer[28] = cfg_is_webusb_landing_enable();
+  shared_io_buffer[28] = device_config_is_webusb_landing_enabled();
   return shared_io_buffer;
 #endif
 }

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -4,6 +4,7 @@
 #include <applets.h>
 #include <common.h>
 #include <ctap.h>
+#include <device-config.h>
 #include <device.h>
 #include <pke.h>
 #if ENABLE_APPLET_NDEF
@@ -466,7 +467,7 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
     for (i = APPLET_NULL + 1; i != end; ++i) {
       if (LC >= AID_Size[i] && memcmp(DATA, AID[i], AID_Size[i]) == 0) {
 #if ENABLE_APPLET_NDEF
-        if (i == APPLET_NDEF && !cfg_is_ndef_enable()) {
+        if (i == APPLET_NDEF && !device_config_is_ndef_enabled()) {
           LL = 0;
           SW = SW_FILE_NOT_FOUND;
           DBG_MSG("NDEF is disable\n");

--- a/src/applets.c
+++ b/src/applets.c
@@ -10,16 +10,17 @@
 #include <pass.h>
 #include <piv.h>
 
-void applets_install(void) {
-  openpgp_install(0);
-  piv_install(0);
-  oath_install(0);
-  ctap_install(0);
-  admin_install(0);
+int applets_install(void) {
+  if (openpgp_install(0) < 0) return -1;
+  if (piv_install(0) < 0) return -1;
+  if (oath_install(0) < 0) return -1;
+  if (ctap_install(0) != 0) return -1;
+  if (admin_install(0) < 0) return -1;
 #if ENABLE_APPLET_NDEF
-  ndef_install(0);
+  if (ndef_install(0) < 0) return -1;
 #endif
-  pass_install(0);
+  if (pass_install(0) < 0) return -1;
+  return 0;
 }
 
 void applets_poweroff(void) {

--- a/src/device.c
+++ b/src/device.c
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "common.h"
-#include <admin.h>
 #include <apdu.h>
 #include <applet-scratch.h>
 #include <applets.h>
@@ -10,6 +9,7 @@
 #if ENABLE_IFACE_CTAPHID
 #include <ctaphid.h>
 #endif
+#include <device-config.h>
 #include <device.h>
 #if ENABLE_IFACE_KBDHID
 #include <kbdhid.h>
@@ -244,7 +244,7 @@ void start_blinking_interval(uint8_t sec, uint32_t interval) {
 
 void stop_blinking(void) {
   blink_timeout = 0;
-  if (cfg_is_led_normally_on()) {
+  if (device_config_is_led_normally_on()) {
     led_on();
     led_status = ON;
   } else {

--- a/src/platform-config.c
+++ b/src/platform-config.c
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <admin.h>
+#include <common.h>
+#include <crc.h>
+#include <ctap.h>
+#include <kbdhid.h>
+#include <piv.h>
+#include <platform-config.h>
+#include <stdalign.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define CONFIG_MAGIC 0x434B4346u // "CKCF"
+#define CONFIG_VERSION 1u
+#define CONFIG_HEADER_LEN 0x20u
+#define CONFIG_KBD_ENTRY_SIZE 2u
+#define CONFIG_KBD_ASCII_COUNT 128u
+#define CONFIG_TLV_SIZE 220u
+#define CONFIG_TLV_EMPTY 0xFFu
+
+#define CONFIG_TLV_CTAP_SM2_CONFIG 0x01u
+#define CONFIG_TLV_PIV_ALG_EXT_CONFIG 0x02u
+#define CONFIG_TLV_CTAP_PERSISTENT_CONFIG 0x03u
+
+#define CONFIG_FLAG_INITIALIZED (1u << 0)
+#define CONFIG_FLAG_NFC_ENABLED (1u << 1)
+#define CONFIG_FLAG_LED_NORMALLY_ON (1u << 2)
+#define CONFIG_FLAG_NDEF_ENABLED (1u << 3)
+#define CONFIG_FLAG_WEBUSB_LANDING_ENABLED (1u << 4)
+#define CONFIG_FLAG_SN_VALID (1u << 5)
+#define CONFIG_FLAG_KBD_KEYMAP_VALID (1u << 6)
+
+// The first word is platform-owned loader handoff state and is excluded from
+// the core config CRC. The rest of the page is owned by this module.
+typedef struct {
+  uint8_t modifier;
+  uint8_t usage;
+} __packed config_kbd_entry_t;
+
+typedef struct {
+  uint32_t platform_word;
+  uint32_t magic;
+  uint8_t version;
+  uint8_t header_len;
+  uint16_t page_len;
+  uint32_t flags;
+  uint8_t serial[4];
+  uint8_t kbd_layout_id;
+  uint8_t kbd_entry_size;
+  uint8_t kbd_first;
+  uint8_t kbd_count;
+  uint8_t reserved[8];
+  config_kbd_entry_t keymap[CONFIG_KBD_ASCII_COUNT];
+  uint8_t tlv[CONFIG_TLV_SIZE];
+  uint32_t crc;
+} __packed config_page_t;
+
+_Static_assert(sizeof(config_page_t) == PLATFORM_CONFIG_PAGE_SIZE,
+               "platform config page must be exactly one flash page");
+_Static_assert(offsetof(config_page_t, keymap) == CONFIG_HEADER_LEN,
+               "platform config keymap must start after the fixed header");
+_Static_assert(offsetof(config_page_t, crc) == PLATFORM_CONFIG_PAGE_SIZE - sizeof(uint32_t),
+               "platform config CRC must be the last word");
+_Static_assert(sizeof(((config_page_t *)0)->keymap) == ADMIN_KBD_KEYMAP_LENGTH,
+               "admin keymap APDU length must match platform config keymap storage");
+
+__weak int platform_config_page_read(size_t off, void *buf, size_t len) {
+  UNUSED(off);
+  UNUSED(buf);
+  UNUSED(len);
+  return -1;
+}
+
+__weak int platform_config_page_write(const void *page, size_t len) {
+  UNUSED(page);
+  UNUSED(len);
+  return -1;
+}
+
+static int config_read_page(config_page_t *page) {
+  return platform_config_page_read(0, page, sizeof(*page));
+}
+
+static uint32_t config_crc_value(const config_page_t *page) {
+  // The platform word may be rewritten without touching config metadata, so
+  // the CRC covers only bytes owned by core.
+  const uint8_t *start = (const uint8_t *)page + offsetof(config_page_t, magic);
+  return crc32_update(CRC32_INIT, start, PLATFORM_CONFIG_PAGE_SIZE - offsetof(config_page_t, magic) - sizeof(page->crc));
+}
+
+static bool config_page_valid(const config_page_t *page) {
+  return page->magic == CONFIG_MAGIC && page->version == CONFIG_VERSION && page->header_len == CONFIG_HEADER_LEN &&
+         page->page_len == PLATFORM_CONFIG_PAGE_SIZE && page->crc == config_crc_value(page);
+}
+
+static bool config_valid(void) {
+  alignas(4) config_page_t page;
+  return config_read_page(&page) == 0 && config_page_valid(&page);
+}
+
+static void config_set_defaults(config_page_t *page, uint32_t platform_word) {
+  memset(page, 0xFF, sizeof(*page));
+  page->platform_word = platform_word;
+  page->magic = CONFIG_MAGIC;
+  page->version = CONFIG_VERSION;
+  page->header_len = CONFIG_HEADER_LEN;
+  page->page_len = PLATFORM_CONFIG_PAGE_SIZE;
+  page->flags = CONFIG_FLAG_NFC_ENABLED | CONFIG_FLAG_LED_NORMALLY_ON | CONFIG_FLAG_NDEF_ENABLED |
+                CONFIG_FLAG_WEBUSB_LANDING_ENABLED;
+  memset(page->serial, 0, sizeof(page->serial));
+  page->kbd_layout_id = 0;
+  page->kbd_entry_size = CONFIG_KBD_ENTRY_SIZE;
+  page->kbd_first = 0;
+  page->kbd_count = CONFIG_KBD_ASCII_COUNT;
+  memset(page->keymap, 0, sizeof(page->keymap));
+  memset(page->tlv, CONFIG_TLV_EMPTY, sizeof(page->tlv));
+  page->crc = config_crc_value(page);
+}
+
+// The fixed keymap consumes most of the page. Small optional configs use this
+// compact TLV tail so adding one does not force a layout bump.
+static bool config_tlv_find(const config_page_t *page, uint8_t type, const uint8_t **value, uint8_t *len) {
+  size_t off = 0;
+  while (off < sizeof(page->tlv)) {
+    const uint8_t item_type = page->tlv[off];
+    if (item_type == CONFIG_TLV_EMPTY) return false;
+    if (off + 2 > sizeof(page->tlv)) return false;
+
+    const uint8_t item_len = page->tlv[off + 1];
+    if (item_len > sizeof(page->tlv) - off - 2) return false;
+
+    if (item_type == type) {
+      if (value != NULL) *value = &page->tlv[off + 2];
+      if (len != NULL) *len = item_len;
+      return true;
+    }
+    off += 2 + item_len;
+  }
+  return false;
+}
+
+static int config_tlv_append(uint8_t *tlv, size_t *off, uint8_t type, const uint8_t *value, uint8_t len) {
+  if (*off > CONFIG_TLV_SIZE || CONFIG_TLV_SIZE - *off < 2 || len > CONFIG_TLV_SIZE - *off - 2) return -1;
+  tlv[(*off)++] = type;
+  tlv[(*off)++] = len;
+  memcpy(&tlv[*off], value, len);
+  *off += len;
+  return 0;
+}
+
+typedef int (*config_update_fn)(config_page_t *page, void *ctx);
+
+static int config_update(config_update_fn update, void *ctx) {
+  alignas(4) config_page_t page;
+
+  // Flash-backed platforms can only rewrite the page as an erase block. Always
+  // copy the full page, repair invalid metadata in RAM, then write one full page.
+  if (config_read_page(&page) < 0) return -1;
+  if (!config_page_valid(&page)) config_set_defaults(&page, page.platform_word);
+
+  if (update(&page, ctx) < 0) return -1;
+
+  uint32_t platform_word = page.platform_word;
+  (void)platform_config_page_read(offsetof(config_page_t, platform_word), &platform_word, sizeof(platform_word));
+  page.platform_word = platform_word;
+  page.crc = config_crc_value(&page);
+  return platform_config_page_write(&page, sizeof(page));
+}
+
+static int set_initialized_update(config_page_t *page, void *ctx) {
+  UNUSED(ctx);
+  page->flags |= CONFIG_FLAG_INITIALIZED;
+  return 0;
+}
+
+static int set_nfc_update(config_page_t *page, void *ctx) {
+  const uint8_t enabled = *(const uint8_t *)ctx;
+  if (enabled)
+    page->flags |= CONFIG_FLAG_NFC_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_NFC_ENABLED;
+  return 0;
+}
+
+static int set_admin_cfg_update(config_page_t *page, void *ctx) {
+  const admin_device_config_t *cfg = (const admin_device_config_t *)ctx;
+  if (cfg->led_normally_on)
+    page->flags |= CONFIG_FLAG_LED_NORMALLY_ON;
+  else
+    page->flags &= ~CONFIG_FLAG_LED_NORMALLY_ON;
+  if (cfg->ndef_en)
+    page->flags |= CONFIG_FLAG_NDEF_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_NDEF_ENABLED;
+  if (cfg->webusb_landing_en)
+    page->flags |= CONFIG_FLAG_WEBUSB_LANDING_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_WEBUSB_LANDING_ENABLED;
+  return 0;
+}
+
+static int set_sn_update(config_page_t *page, void *ctx) {
+  const uint8_t *sn = (const uint8_t *)ctx;
+  memcpy(page->serial, sn, sizeof(page->serial));
+  page->flags |= CONFIG_FLAG_SN_VALID;
+  return 0;
+}
+
+typedef struct {
+  uint8_t layout_id;
+  const uint8_t *keymap;
+} keymap_update_t;
+
+static int set_keymap_update(config_page_t *page, void *ctx) {
+  const keymap_update_t *keymap = (const keymap_update_t *)ctx;
+  page->kbd_layout_id = keymap->layout_id;
+  page->kbd_entry_size = CONFIG_KBD_ENTRY_SIZE;
+  page->kbd_first = 0;
+  page->kbd_count = CONFIG_KBD_ASCII_COUNT;
+  memcpy(page->keymap, keymap->keymap, sizeof(page->keymap));
+  page->flags |= CONFIG_FLAG_KBD_KEYMAP_VALID;
+  return 0;
+}
+
+static int clear_keymap_update(config_page_t *page, void *ctx) {
+  UNUSED(ctx);
+  page->kbd_layout_id = 0;
+  page->kbd_entry_size = CONFIG_KBD_ENTRY_SIZE;
+  page->kbd_first = 0;
+  page->kbd_count = CONFIG_KBD_ASCII_COUNT;
+  memset(page->keymap, 0, sizeof(page->keymap));
+  page->flags &= ~CONFIG_FLAG_KBD_KEYMAP_VALID;
+  return 0;
+}
+
+typedef struct {
+  uint8_t type;
+  const uint8_t *value;
+  uint8_t len;
+} tlv_update_t;
+
+static int set_tlv_update(config_page_t *page, void *ctx) {
+  const tlv_update_t *update = (const tlv_update_t *)ctx;
+  uint8_t tlv[CONFIG_TLV_SIZE];
+  size_t src = 0;
+  size_t dst = 0;
+
+  // Rebuild the TLV tail instead of patching in place. Flash writes still go
+  // through config_update(), and rebuilding keeps replaced values compact.
+  memset(tlv, CONFIG_TLV_EMPTY, sizeof(tlv));
+  while (src < sizeof(page->tlv)) {
+    const uint8_t item_type = page->tlv[src];
+    if (item_type == CONFIG_TLV_EMPTY) break;
+    if (src + 2 > sizeof(page->tlv)) break;
+
+    const uint8_t item_len = page->tlv[src + 1];
+    if (item_len > sizeof(page->tlv) - src - 2) break;
+    if (item_type != update->type && config_tlv_append(tlv, &dst, item_type, &page->tlv[src + 2], item_len) < 0)
+      return -1;
+    src += 2 + item_len;
+  }
+
+  if (config_tlv_append(tlv, &dst, update->type, update->value, update->len) < 0) return -1;
+  memcpy(page->tlv, tlv, sizeof(page->tlv));
+  return 0;
+}
+
+static int config_tlv_read(uint8_t type, uint8_t *value, uint8_t len) {
+  alignas(4) config_page_t page;
+  const uint8_t *stored;
+  uint8_t stored_len;
+
+  if (config_read_page(&page) < 0 || !config_page_valid(&page) || !config_tlv_find(&page, type, &stored, &stored_len) ||
+      stored_len != len)
+    return -1;
+  memcpy(value, stored, len);
+  return 0;
+}
+
+static int config_tlv_write(uint8_t type, const uint8_t *value, uint8_t len) {
+  tlv_update_t update = {.type = type, .value = value, .len = len};
+  return config_update(set_tlv_update, &update);
+}
+
+int admin_platform_device_config_read(admin_device_config_t *cfg) {
+  alignas(4) config_page_t page;
+  if (config_read_page(&page) < 0 || !config_page_valid(&page)) return -1;
+  cfg->led_normally_on = (page.flags & CONFIG_FLAG_LED_NORMALLY_ON) != 0;
+  cfg->ndef_en = (page.flags & CONFIG_FLAG_NDEF_ENABLED) != 0;
+  cfg->webusb_landing_en = (page.flags & CONFIG_FLAG_WEBUSB_LANDING_ENABLED) != 0;
+  return 0;
+}
+
+int admin_platform_device_config_write(const admin_device_config_t *cfg) {
+  return config_update(set_admin_cfg_update, (void *)cfg);
+}
+
+int admin_platform_serial_read(uint8_t *buf) {
+  alignas(4) config_page_t page;
+  if (config_read_page(&page) < 0 || !config_page_valid(&page) || (page.flags & CONFIG_FLAG_SN_VALID) == 0) return -1;
+  memcpy(buf, page.serial, sizeof(page.serial));
+  return 0;
+}
+
+int admin_platform_serial_write_once(const uint8_t *buf) {
+  if (config_valid()) {
+    alignas(4) config_page_t page;
+    if (config_read_page(&page) == 0 && config_page_valid(&page) && (page.flags & CONFIG_FLAG_SN_VALID) != 0)
+      return -1;
+  }
+  return config_update(set_sn_update, (void *)buf);
+}
+
+int admin_platform_kbd_keymap_write(uint8_t layout_id, const uint8_t *keymap, uint16_t len) {
+  if (keymap == NULL || len != sizeof(((config_page_t *)0)->keymap)) return -1;
+  keymap_update_t update = {.layout_id = layout_id, .keymap = keymap};
+  return config_update(set_keymap_update, &update);
+}
+
+int admin_platform_kbd_keymap_read(uint8_t *layout_id, uint8_t *keymap, uint16_t len) {
+  alignas(4) config_page_t page;
+  if (layout_id == NULL) return -1;
+  if ((keymap == NULL && len != 0) || (keymap != NULL && len != sizeof(page.keymap))) return -1;
+  if (config_read_page(&page) < 0 || !config_page_valid(&page) || (page.flags & CONFIG_FLAG_KBD_KEYMAP_VALID) == 0)
+    return -1;
+  if (page.kbd_entry_size != CONFIG_KBD_ENTRY_SIZE || page.kbd_first != 0 || page.kbd_count != CONFIG_KBD_ASCII_COUNT)
+    return -1;
+  *layout_id = page.kbd_layout_id;
+  if (keymap != NULL) memcpy(keymap, page.keymap, sizeof(page.keymap));
+  return 0;
+}
+
+int admin_platform_kbd_keymap_clear(void) { return config_update(clear_keymap_update, NULL); }
+
+int ctap_platform_sm2_config_read(void *cfg, size_t len) {
+  // The TLV length field is one byte; reject unexpected larger core structs
+  // instead of silently truncating a future config.
+  if (len > UINT8_MAX) return -1;
+  return config_tlv_read(CONFIG_TLV_CTAP_SM2_CONFIG, cfg, (uint8_t)len);
+}
+
+int ctap_platform_sm2_config_write(const void *cfg, size_t len) {
+  if (len > UINT8_MAX) return -1;
+  return config_tlv_write(CONFIG_TLV_CTAP_SM2_CONFIG, cfg, (uint8_t)len);
+}
+
+int ctap_platform_persistent_config_read(void *cfg, size_t len) {
+  if (len > UINT8_MAX) return -1;
+  return config_tlv_read(CONFIG_TLV_CTAP_PERSISTENT_CONFIG, cfg, (uint8_t)len);
+}
+
+int ctap_platform_persistent_config_write(const void *cfg, size_t len) {
+  if (len > UINT8_MAX) return -1;
+  return config_tlv_write(CONFIG_TLV_CTAP_PERSISTENT_CONFIG, cfg, (uint8_t)len);
+}
+
+int piv_platform_algorithm_extension_config_read(piv_algorithm_extension_config_t *cfg) {
+  return config_tlv_read(CONFIG_TLV_PIV_ALG_EXT_CONFIG, (uint8_t *)cfg, sizeof(*cfg));
+}
+
+int piv_platform_algorithm_extension_config_write(const piv_algorithm_extension_config_t *cfg) {
+  return config_tlv_write(CONFIG_TLV_PIV_ALG_EXT_CONFIG, (const uint8_t *)cfg, sizeof(*cfg));
+}
+
+bool kbdhid_platform_translate_ascii(uint8_t ch, uint8_t *modifier, uint8_t *usage) {
+  alignas(4) config_page_t page;
+  if (config_read_page(&page) < 0 || !config_page_valid(&page) || (page.flags & CONFIG_FLAG_KBD_KEYMAP_VALID) == 0)
+    return false;
+  if (page.kbd_entry_size != CONFIG_KBD_ENTRY_SIZE || page.kbd_first != 0 || page.kbd_count != CONFIG_KBD_ASCII_COUNT ||
+      ch >= CONFIG_KBD_ASCII_COUNT)
+    return false;
+
+  // A valid platform keymap is authoritative. usage == 0 means "skip this
+  // character", not "fall back to the built-in QWERTY map".
+  const config_kbd_entry_t *entry = &page.keymap[ch];
+  *modifier = entry->modifier;
+  *usage = entry->usage;
+  return true;
+}
+
+uint8_t device_config_is_initialized(void) {
+  alignas(4) config_page_t page;
+  if (config_read_page(&page) < 0 || !config_page_valid(&page)) return 0;
+  return (page.flags & CONFIG_FLAG_INITIALIZED) != 0;
+}
+
+int device_config_mark_initialized(void) {
+  if (device_config_is_initialized()) return 0;
+  return config_update(set_initialized_update, NULL);
+}
+
+uint8_t device_config_is_nfc_enabled(void) {
+  alignas(4) config_page_t page;
+  if (config_read_page(&page) < 0 || !config_page_valid(&page)) return 1;
+  return (page.flags & CONFIG_FLAG_NFC_ENABLED) != 0;
+}
+
+int device_config_set_nfc_enabled(uint8_t enabled) { return config_update(set_nfc_update, &enabled); }

--- a/test-via-pcsc/admin_test.go
+++ b/test-via-pcsc/admin_test.go
@@ -200,7 +200,7 @@ func commandTests(verified bool, app *AdminApplet) func(C) {
 			shadowCfg := []byte{0x01, 0x00, 0x00, 0x01, 0x01, 0x00}
 			P1toIdx := map[int]int{
 				1: 0, // ADMIN_P1_CFG_LED_ON
-				2: 2, // ndef_get_read_only
+				2: 2, // NDEF read-only CC flag
 				// 3: 1, // ADMIN_P1_CFG_KBDIFACE (obsolete)
 				4: 3, // ADMIN_P1_CFG_NDEF
 				5: 4, // ADMIN_P1_CFG_WEBUSB_LANDING

--- a/test/test_apdu.c
+++ b/test/test_apdu.c
@@ -712,7 +712,7 @@ static void test_fido_chained_make_credential_nfc(void **state) {
   // though init_apdu_buffer() cleared the selected applet.
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
   assert_int_equal(ctap_nfc_pending_active(), 1);
 
   static const uint8_t nfc_get_response[] = {
@@ -794,7 +794,7 @@ static void test_fido_reset_nfc_returns_keepalive_pending(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
   testmode_set_initial_ticks(0);
   testmode_set_initial_ticks(device_get_tick());
   set_nfc_state(1);
@@ -825,7 +825,7 @@ static void test_fido_cbor_after_reset_without_select(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(build_capdu(&capdu, get_info_apdu, sizeof(get_info_apdu)), 0);
   process_apdu(&capdu, &rapdu);
@@ -849,7 +849,7 @@ static void test_fido_chained_cbor_after_reset_without_select(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(build_capdu(&capdu, get_info_apdu, sizeof(get_info_apdu)), 0);
   process_apdu(&capdu, &rapdu);
@@ -868,7 +868,7 @@ static void test_ctap_deselect_clears_get_next_assertion_state(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   ctap_test_seed_get_next_assertion_state();
   ctap_deselect();
@@ -883,7 +883,7 @@ static void test_ctap_poweroff_keeps_credential_management_state(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   ctap_test_seed_credential_management_state();
   ctap_poweroff();
@@ -896,7 +896,7 @@ static void test_ctap_deselect_clears_credential_management_state(void **state) 
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   ctap_test_seed_credential_management_state();
   ctap_deselect();
@@ -923,7 +923,7 @@ static void test_ctap_hid_get_info_stream_source(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(ctap_process_cbor_stream_with_src(req, sizeof(req), scratch, sizeof(scratch), &source, CTAP_SRC_HID),
                    1);
@@ -948,7 +948,7 @@ static void test_ctap_config_empty_request_is_legacy_unhandled(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(ctap_process_cbor_with_src(config_req, sizeof(config_req), resp, &resp_len, CTAP_SRC_HID), 0);
   assert_int_equal(resp_len, 1);
@@ -969,7 +969,7 @@ static void test_ctap_config_toggle_always_uv_without_pin(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(ctap_process_cbor_with_src(config_req, sizeof(config_req), resp, &resp_len, CTAP_SRC_HID), 0);
   assert_int_equal(resp_len, 1);
@@ -1015,7 +1015,7 @@ static void test_ctap_hid_make_credential_accepts_p9_pub_key_param_order(void **
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(ctap_process_cbor_stream_with_src(req, sizeof(req), scratch, sizeof(scratch), &source, CTAP_SRC_HID),
                    1);
@@ -1038,7 +1038,7 @@ static void test_ctap_hid_make_credential_hmac_secret_mc_requires_hmac_secret(vo
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(ctap_process_cbor_with_src(req, req_len, resp, &resp_len, CTAP_SRC_HID), 0);
   assert_int_equal(resp_len, 1);
@@ -1067,7 +1067,7 @@ static void test_ctap_hid_make_credential_hmac_secret_mc_output_key_is_separate(
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(write_attr("ctap_cert", 0, fido_private_key, sizeof(fido_private_key)), 0);
   assert_int_equal(write_file("ctap_cert", cert, 0, sizeof(cert), 1), 0);
@@ -1117,7 +1117,7 @@ static void test_ctap_hid_make_credential_mldsa_hmac_secret_mc_output_key_is_sep
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
   memset(resp, 0, sizeof(resp));
   memset(auth_data_buf, 0, sizeof(auth_data_buf));
 
@@ -1170,7 +1170,7 @@ static void test_ctap_hid_third_party_payment_round_trip(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(write_attr("ctap_cert", 0, fido_private_key, sizeof(fido_private_key)), 0);
   assert_int_equal(write_file("ctap_cert", cert, 0, sizeof(cert), 1), 0);
@@ -1230,7 +1230,7 @@ static void test_ctap_hid_credential_management_returns_third_party_payment(void
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(write_attr("ctap_cert", 0, fido_private_key, sizeof(fido_private_key)), 0);
   assert_int_equal(write_file("ctap_cert", cert, 0, sizeof(cert), 1), 0);
@@ -1299,7 +1299,7 @@ static void test_ctap_hid_large_cbor_response_keeps_payload(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   for (size_t i = 0; i < sizeof(blob); ++i) {
     blob[i] = (uint8_t)i;
@@ -1336,7 +1336,7 @@ static void test_get_response_after_reset_without_pending_response(void **state)
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(build_capdu(&capdu, get_response, sizeof(get_response)), 0);
   process_apdu(&capdu, &rapdu);
@@ -1593,7 +1593,7 @@ static void test_fido_apdu_chain_overflow_returns_wrong_length(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
   set_nfc_state(0);
 
   assert_int_equal(build_capdu(&capdu, select_fido, sizeof(select_fido)), 0);
@@ -1659,7 +1659,7 @@ static void test_fido_magic_reboot_after_reset_without_select(void **state) {
 
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   assert_int_equal(build_capdu(&capdu, magic_reboot_apdu, sizeof(magic_reboot_apdu)), 0);
   process_apdu(&capdu, &rapdu);
@@ -1692,7 +1692,7 @@ int main() {
   fs_mount(&cfg);
   init_apdu_buffer();
   device_init();
-  applets_install();
+  assert_int_equal(applets_install(), 0);
 
   const struct CMUnitTest tests[] = {
       cmocka_unit_test(test_input_chaining),

--- a/test/test_apdu.c
+++ b/test/test_apdu.c
@@ -5,12 +5,14 @@
 #include <stdint.h>
 #include <cmocka.h>
 
+#include <admin.h>
 #include <applets.h>
 #include <applet-scratch.h>
 #include <apdu.h>
 #include <bd/lfs_filebd.h>
 #include <ccid.h>
 #include <ctap.h>
+#include <device-config.h>
 #include <device.h>
 #include <fs.h>
 #include <lfs.h>
@@ -1668,6 +1670,165 @@ static void test_fido_magic_reboot_after_reset_without_select(void **state) {
   assert_int_equal(rapdu.sw, SW_NO_ERROR);
 }
 
+static void admin_send(CAPDU *capdu, RAPDU *rapdu, uint8_t ins, uint8_t p1, uint8_t p2, const uint8_t *data,
+                       uint16_t lc, uint32_t le) {
+  capdu->cla = 0x00;
+  capdu->ins = ins;
+  capdu->p1 = p1;
+  capdu->p2 = p2;
+  capdu->lc = lc;
+  capdu->le = le;
+  if (lc > 0) memcpy(capdu->data, data, lc);
+
+  admin_process_apdu(capdu, rapdu);
+}
+
+static void admin_verify_default_pin(CAPDU *capdu, RAPDU *rapdu) {
+  static const uint8_t default_pin[] = {'1', '2', '3', '4', '5', '6'};
+
+  admin_send(capdu, rapdu, ADMIN_INS_VERIFY, 0x00, 0x00, default_pin, sizeof(default_pin), 0);
+  assert_int_equal(rapdu->sw, SW_NO_ERROR);
+  assert_int_equal(rapdu->len, 0);
+}
+
+static void test_admin_platform_config_and_serial_apdus(void **state) {
+  (void)state;
+
+  uint8_t c_buf[ADMIN_KBD_KEYMAP_LENGTH];
+  uint8_t r_buf[ADMIN_KBD_KEYMAP_LENGTH];
+  CAPDU capdu = {.data = c_buf};
+  RAPDU rapdu = {.data = r_buf};
+
+  init_apdu_buffer();
+  device_init();
+  assert_int_equal(admin_install(1), 0);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_CONFIG, 0x00, 0x00, NULL, 0, 6);
+  assert_int_equal(rapdu.sw, SW_SECURITY_STATUS_NOT_SATISFIED);
+
+  admin_verify_default_pin(&capdu, &rapdu);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_CONFIG, 0x01, 0x00, NULL, 0, 6);
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_CONFIG, 0x00, 0x00, NULL, 0, 5);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_CONFIG, 0x00, 0x00, NULL, 0, 6);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, 6);
+  assert_int_equal(rapdu.data[0], 1);
+  assert_int_equal(rapdu.data[3], 1);
+  assert_int_equal(rapdu.data[4], 1);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_LED_ON, 0x00, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(device_config_is_led_normally_on(), 0);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_NDEF, 0x00, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(device_config_is_ndef_enabled(), 0);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_WEBUSB_LANDING, 0x00, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(device_config_is_webusb_landing_enabled(), 0);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, 0x7F, 0x00, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_CONFIG, 0x00, 0x00, NULL, 0, 6);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, 6);
+  assert_int_equal(rapdu.data[0], 0);
+  assert_int_equal(rapdu.data[3], 0);
+  assert_int_equal(rapdu.data[4], 0);
+
+  uint8_t serial[4];
+  device_config_fill_serial(serial);
+  assert_memory_equal(serial, "\x00\x00\x00\x00", sizeof(serial));
+
+  const uint8_t expected_serial[] = {0xA1, 0xB2, 0xC3, 0xD4};
+  admin_send(&capdu, &rapdu, ADMIN_INS_WRITE_SN, 0x00, 0x00, expected_serial, sizeof(expected_serial), 0);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_SN, 0x00, 0x00, NULL, 0, sizeof(expected_serial));
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, sizeof(expected_serial));
+  assert_memory_equal(rapdu.data, expected_serial, sizeof(expected_serial));
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_WRITE_SN, 0x00, 0x00, expected_serial, sizeof(expected_serial), 0);
+  assert_int_equal(rapdu.sw, SW_CONDITIONS_NOT_SATISFIED);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_SN, 0x00, 0x00, NULL, 0, sizeof(expected_serial) - 1);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+}
+
+static void test_admin_kbd_keymap_apdus(void **state) {
+  (void)state;
+
+  uint8_t c_buf[ADMIN_KBD_KEYMAP_LENGTH];
+  uint8_t r_buf[ADMIN_KBD_KEYMAP_LENGTH];
+  uint8_t keymap[ADMIN_KBD_KEYMAP_LENGTH];
+  CAPDU capdu = {.data = c_buf};
+  RAPDU rapdu = {.data = r_buf};
+
+  init_apdu_buffer();
+  device_init();
+  assert_int_equal(admin_install(1), 0);
+  admin_verify_default_pin(&capdu, &rapdu);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, ADMIN_P2_KBD_READ_LAYOUT_ID, NULL, 0, 1);
+  assert_int_equal(rapdu.sw, SW_REFERENCE_DATA_NOT_FOUND);
+
+  for (size_t i = 0; i < sizeof(keymap); ++i)
+    keymap[i] = (uint8_t)(i ^ 0x5A);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_WRITE_KBD_KEYMAP, 0x01, 0x33, keymap, sizeof(keymap), 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_WRITE_KBD_KEYMAP, 0x00, 0x33, keymap, sizeof(keymap) - 1, 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_WRITE_KBD_KEYMAP, 0x00, 0x33, keymap, sizeof(keymap), 0);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, 0);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, ADMIN_P2_KBD_READ_LAYOUT_ID, NULL, 0, 1);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, 1);
+  assert_int_equal(rapdu.data[0], 0x33);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, ADMIN_P2_KBD_READ_KEYMAP, NULL, 0,
+             ADMIN_KBD_KEYMAP_LENGTH - 1);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, ADMIN_P2_KBD_READ_KEYMAP, keymap, 1,
+             ADMIN_KBD_KEYMAP_LENGTH);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, ADMIN_P2_KBD_READ_KEYMAP, NULL, 0,
+             ADMIN_KBD_KEYMAP_LENGTH);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, ADMIN_KBD_KEYMAP_LENGTH);
+  assert_memory_equal(rapdu.data, keymap, sizeof(keymap));
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, 0x7F, NULL, 0, 1);
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CLEAR_KBD_KEYMAP, 0x00, 0x01, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CLEAR_KBD_KEYMAP, 0x00, 0x00, keymap, 1, 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_CLEAR_KBD_KEYMAP, 0x00, 0x00, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_KBD_KEYMAP, 0x00, ADMIN_P2_KBD_READ_KEYMAP, NULL, 0,
+             ADMIN_KBD_KEYMAP_LENGTH);
+  assert_int_equal(rapdu.sw, SW_REFERENCE_DATA_NOT_FOUND);
+}
+
 int main() {
   struct lfs_config cfg;
   lfs_filebd_t bd;
@@ -1729,6 +1890,8 @@ int main() {
       cmocka_unit_test(test_fido_apdu_chain_overflow_returns_wrong_length),
       cmocka_unit_test(test_response_source_clear_calls_close),
       cmocka_unit_test(test_fido_magic_reboot_after_reset_without_select),
+      cmocka_unit_test(test_admin_platform_config_and_serial_apdus),
+      cmocka_unit_test(test_admin_kbd_keymap_apdus),
   };
 
   int ret = cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/test_core_helpers.c
+++ b/test/test_core_helpers.c
@@ -174,7 +174,7 @@ uint8_t KBDHID_Loop(void) {
   return 0;
 }
 
-uint8_t cfg_is_led_normally_on(void) { return led_normally_on ? 1 : 0; }
+uint8_t device_config_is_led_normally_on(void) { return led_normally_on ? 1 : 0; }
 
 static void test_tlv_get_length_safe_variants(void **state) {
   (void)state;

--- a/test/test_core_helpers.c
+++ b/test/test_core_helpers.c
@@ -10,6 +10,7 @@
 #include <device.h>
 #include <fs.h>
 #include <lfs.h>
+#include <platform-config.h>
 #include <pin.h>
 #include <stdbool.h>
 #include <string.h>
@@ -32,6 +33,7 @@ static uint8_t ctaphid_wait_result;
 static bool led_normally_on;
 static bool inject_write_error;
 static char inject_write_error_path[64];
+static uint8_t test_config_page[PLATFORM_CONFIG_PAGE_SIZE];
 
 typedef enum {
   AUTO_TOUCH_NONE = 0,
@@ -59,6 +61,7 @@ static void reset_test_state(void) {
   led_normally_on = false;
   inject_write_error = false;
   inject_write_error_path[0] = 0;
+  memset(test_config_page, 0xFF, sizeof(test_config_page));
   auto_touch_mode = AUTO_TOUCH_NONE;
 }
 
@@ -171,6 +174,18 @@ void WebUSB_Loop(void) { webusb_loop_calls++; }
 
 uint8_t KBDHID_Loop(void) {
   kbdhid_loop_calls++;
+  return 0;
+}
+
+int platform_config_page_read(size_t off, void *buf, size_t len) {
+  if (buf == NULL || off > sizeof(test_config_page) || len > sizeof(test_config_page) - off) return -1;
+  memcpy(buf, test_config_page + off, len);
+  return 0;
+}
+
+int platform_config_page_write(const void *page, size_t len) {
+  if (page == NULL || len != sizeof(test_config_page)) return -1;
+  memcpy(test_config_page, page, sizeof(test_config_page));
   return 0;
 }
 

--- a/test/test_piv.c
+++ b/test/test_piv.c
@@ -319,6 +319,53 @@ static void test_piv_get_metadata_extended_algo_ids(void **state) {
   }
 }
 
+static void test_piv_reset_preserves_platform_algorithm_extension(void **state) {
+  (void)state;
+
+  const piv_algorithm_extension_config_t custom = {
+      .enabled = 1,
+      .ed25519 = 0x22,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x51,
+      .x25519 = 0x52,
+      .secp256k1 = 0x53,
+      .sm2 = 0x54,
+  };
+  assert_int_equal(piv_platform_algorithm_extension_config_write(&custom), 0);
+
+  // A PIV reset rebuilds LittleFS-backed applet state, but the algorithm
+  // extension record belongs to platform configuration and must survive it.
+  assert_int_equal(piv_install(1), 0);
+
+  piv_algorithm_extension_config_t actual;
+  assert_int_equal(piv_platform_algorithm_extension_config_read(&actual), 0);
+  assert_memory_equal(&actual, &custom, sizeof(custom));
+
+  set_admin_status(1);
+  uint8_t generate_ed25519[] = {0xAC, 0x03, 0x80, 0x01, custom.ed25519};
+  uint8_t r_buf[128];
+  CAPDU C = {.data = generate_ed25519,
+             .ins = PIV_INS_GENERATE_ASYMMETRIC_KEY_PAIR,
+             .p1 = 0x00,
+             .p2 = 0x9A,
+             .lc = sizeof(generate_ed25519)};
+  RAPDU R = {.data = r_buf};
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+
+  const piv_algorithm_extension_config_t defaults = {
+      .enabled = 1,
+      .ed25519 = 0xE0,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x16,
+      .x25519 = 0xE1,
+      .secp256k1 = 0x53,
+      .sm2 = 0x54,
+  };
+  assert_int_equal(piv_platform_algorithm_extension_config_write(&defaults), 0);
+  assert_int_equal(piv_install(1), 0);
+}
+
 static void test_ed25519_general_authenticate_long_message(void **state) {
   (void)state;
 
@@ -603,6 +650,7 @@ int main() {
       cmocka_unit_test(test_piv_retired_cert_lazy_storage),
       cmocka_unit_test(test_piv_metadata_bounded_do_storage),
       cmocka_unit_test(test_piv_get_metadata_extended_algo_ids),
+      cmocka_unit_test(test_piv_reset_preserves_platform_algorithm_extension),
       cmocka_unit_test(test_ed25519_general_authenticate_long_message),
       cmocka_unit_test(test_set_pin_retries),
       cmocka_unit_test(test_set_pin_retries_failure_invalidates_auth),

--- a/virt-card/device-sim.c
+++ b/virt-card/device-sim.c
@@ -2,6 +2,9 @@
 // implement software-simulated device funtions (LED, Touch, Timer, etc.)
 #include "device.h"
 #include "admin.h"
+#include "ctap.h"
+#include "ndef.h"
+#include "piv.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -16,6 +19,17 @@
 
 static uint32_t initial_ticks = 0;
 static char err_trigger_filename[64];
+static admin_device_config_t simulated_admin_cfg = {.led_normally_on = 1, .ndef_en = 1, .webusb_landing_en = 1};
+static uint8_t simulated_sn[4];
+static bool simulated_sn_valid;
+static uint8_t simulated_sm2_cfg[16];
+static size_t simulated_sm2_cfg_len;
+static bool simulated_sm2_cfg_valid;
+static uint8_t simulated_ctap_cfg[16];
+static size_t simulated_ctap_cfg_len;
+static bool simulated_ctap_cfg_valid;
+static piv_algorithm_extension_config_t simulated_piv_alg_cfg;
+static bool simulated_piv_alg_cfg_valid;
 
 int admin_vendor_version(const CAPDU *capdu, RAPDU *rapdu) {
   LL = strlen(GIT_REV);
@@ -45,6 +59,69 @@ int admin_vendor_hw_sn(const CAPDU *capdu, RAPDU *rapdu) {
   LL = 1;
   if (LL > LE) LL = LE;
 
+  return 0;
+}
+
+int admin_platform_device_config_read(admin_device_config_t *cfg) {
+  *cfg = simulated_admin_cfg;
+  return 0;
+}
+
+int admin_platform_device_config_write(const admin_device_config_t *cfg) {
+  simulated_admin_cfg = *cfg;
+  return 0;
+}
+
+int admin_platform_serial_read(uint8_t *buf) {
+  if (!simulated_sn_valid) return -1;
+  memcpy(buf, simulated_sn, sizeof(simulated_sn));
+  return 0;
+}
+
+int admin_platform_serial_write_once(const uint8_t *buf) {
+  if (simulated_sn_valid) return -1;
+  memcpy(simulated_sn, buf, sizeof(simulated_sn));
+  simulated_sn_valid = true;
+  return 0;
+}
+
+int ctap_platform_sm2_config_read(void *cfg, size_t len) {
+  if (!simulated_sm2_cfg_valid || len != simulated_sm2_cfg_len) return -1;
+  memcpy(cfg, simulated_sm2_cfg, len);
+  return 0;
+}
+
+int ctap_platform_sm2_config_write(const void *cfg, size_t len) {
+  if (len > sizeof(simulated_sm2_cfg)) return -1;
+  memcpy(simulated_sm2_cfg, cfg, len);
+  simulated_sm2_cfg_len = len;
+  simulated_sm2_cfg_valid = true;
+  return 0;
+}
+
+int ctap_platform_persistent_config_read(void *cfg, size_t len) {
+  if (!simulated_ctap_cfg_valid || len != simulated_ctap_cfg_len) return -1;
+  memcpy(cfg, simulated_ctap_cfg, len);
+  return 0;
+}
+
+int ctap_platform_persistent_config_write(const void *cfg, size_t len) {
+  if (len > sizeof(simulated_ctap_cfg)) return -1;
+  memcpy(simulated_ctap_cfg, cfg, len);
+  simulated_ctap_cfg_len = len;
+  simulated_ctap_cfg_valid = true;
+  return 0;
+}
+
+int piv_platform_algorithm_extension_config_read(piv_algorithm_extension_config_t *cfg) {
+  if (!simulated_piv_alg_cfg_valid) return -1;
+  *cfg = simulated_piv_alg_cfg;
+  return 0;
+}
+
+int piv_platform_algorithm_extension_config_write(const piv_algorithm_extension_config_t *cfg) {
+  simulated_piv_alg_cfg = *cfg;
+  simulated_piv_alg_cfg_valid = true;
   return 0;
 }
 

--- a/virt-card/device-sim.c
+++ b/virt-card/device-sim.c
@@ -5,6 +5,7 @@
 #include "ctap.h"
 #include "ndef.h"
 #include "piv.h"
+#include <platform-config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -19,20 +20,14 @@
 
 static uint32_t initial_ticks = 0;
 static char err_trigger_filename[64];
-static admin_device_config_t simulated_admin_cfg = {.led_normally_on = 1, .ndef_en = 1, .webusb_landing_en = 1};
-static uint8_t simulated_sn[4];
-static bool simulated_sn_valid;
-static uint8_t simulated_sm2_cfg[16];
-static size_t simulated_sm2_cfg_len;
-static bool simulated_sm2_cfg_valid;
-static uint8_t simulated_ctap_cfg[16];
-static size_t simulated_ctap_cfg_len;
-static bool simulated_ctap_cfg_valid;
-static piv_algorithm_extension_config_t simulated_piv_alg_cfg;
-static bool simulated_piv_alg_cfg_valid;
-static uint8_t simulated_kbd_layout_id;
-static uint8_t simulated_kbd_keymap[ADMIN_KBD_KEYMAP_LENGTH];
-static bool simulated_kbd_keymap_valid;
+static uint8_t simulated_config_page[PLATFORM_CONFIG_PAGE_SIZE];
+static bool simulated_config_page_loaded;
+
+static void simulated_config_page_init(void) {
+  if (simulated_config_page_loaded) return;
+  memset(simulated_config_page, 0xFF, sizeof(simulated_config_page));
+  simulated_config_page_loaded = true;
+}
 
 int admin_vendor_version(const CAPDU *capdu, RAPDU *rapdu) {
   LL = strlen(GIT_REV);
@@ -65,91 +60,17 @@ int admin_vendor_hw_sn(const CAPDU *capdu, RAPDU *rapdu) {
   return 0;
 }
 
-int admin_platform_device_config_read(admin_device_config_t *cfg) {
-  *cfg = simulated_admin_cfg;
+int platform_config_page_read(size_t off, void *buf, size_t len) {
+  if (buf == NULL || off > sizeof(simulated_config_page) || len > sizeof(simulated_config_page) - off) return -1;
+  simulated_config_page_init();
+  memcpy(buf, simulated_config_page + off, len);
   return 0;
 }
 
-int admin_platform_device_config_write(const admin_device_config_t *cfg) {
-  simulated_admin_cfg = *cfg;
-  return 0;
-}
-
-int admin_platform_serial_read(uint8_t *buf) {
-  if (!simulated_sn_valid) return -1;
-  memcpy(buf, simulated_sn, sizeof(simulated_sn));
-  return 0;
-}
-
-int admin_platform_serial_write_once(const uint8_t *buf) {
-  if (simulated_sn_valid) return -1;
-  memcpy(simulated_sn, buf, sizeof(simulated_sn));
-  simulated_sn_valid = true;
-  return 0;
-}
-
-int admin_platform_kbd_keymap_write(uint8_t layout_id, const uint8_t *keymap, uint16_t len) {
-  if (len != ADMIN_KBD_KEYMAP_LENGTH) return -1;
-  simulated_kbd_layout_id = layout_id;
-  memcpy(simulated_kbd_keymap, keymap, sizeof(simulated_kbd_keymap));
-  simulated_kbd_keymap_valid = true;
-  return 0;
-}
-
-int admin_platform_kbd_keymap_read(uint8_t *layout_id, uint8_t *keymap, uint16_t len) {
-  if (!simulated_kbd_keymap_valid) return -1;
-  if (layout_id) *layout_id = simulated_kbd_layout_id;
-  if (keymap) {
-    if (len != ADMIN_KBD_KEYMAP_LENGTH) return -1;
-    memcpy(keymap, simulated_kbd_keymap, sizeof(simulated_kbd_keymap));
-  }
-  return 0;
-}
-
-int admin_platform_kbd_keymap_clear(void) {
-  memset(simulated_kbd_keymap, 0, sizeof(simulated_kbd_keymap));
-  simulated_kbd_layout_id = 0;
-  simulated_kbd_keymap_valid = false;
-  return 0;
-}
-
-int ctap_platform_sm2_config_read(void *cfg, size_t len) {
-  if (!simulated_sm2_cfg_valid || len != simulated_sm2_cfg_len) return -1;
-  memcpy(cfg, simulated_sm2_cfg, len);
-  return 0;
-}
-
-int ctap_platform_sm2_config_write(const void *cfg, size_t len) {
-  if (len > sizeof(simulated_sm2_cfg)) return -1;
-  memcpy(simulated_sm2_cfg, cfg, len);
-  simulated_sm2_cfg_len = len;
-  simulated_sm2_cfg_valid = true;
-  return 0;
-}
-
-int ctap_platform_persistent_config_read(void *cfg, size_t len) {
-  if (!simulated_ctap_cfg_valid || len != simulated_ctap_cfg_len) return -1;
-  memcpy(cfg, simulated_ctap_cfg, len);
-  return 0;
-}
-
-int ctap_platform_persistent_config_write(const void *cfg, size_t len) {
-  if (len > sizeof(simulated_ctap_cfg)) return -1;
-  memcpy(simulated_ctap_cfg, cfg, len);
-  simulated_ctap_cfg_len = len;
-  simulated_ctap_cfg_valid = true;
-  return 0;
-}
-
-int piv_platform_algorithm_extension_config_read(piv_algorithm_extension_config_t *cfg) {
-  if (!simulated_piv_alg_cfg_valid) return -1;
-  *cfg = simulated_piv_alg_cfg;
-  return 0;
-}
-
-int piv_platform_algorithm_extension_config_write(const piv_algorithm_extension_config_t *cfg) {
-  simulated_piv_alg_cfg = *cfg;
-  simulated_piv_alg_cfg_valid = true;
+int platform_config_page_write(const void *page, size_t len) {
+  if (page == NULL || len != sizeof(simulated_config_page)) return -1;
+  simulated_config_page_init();
+  memcpy(simulated_config_page, page, sizeof(simulated_config_page));
   return 0;
 }
 

--- a/virt-card/device-sim.c
+++ b/virt-card/device-sim.c
@@ -30,6 +30,9 @@ static size_t simulated_ctap_cfg_len;
 static bool simulated_ctap_cfg_valid;
 static piv_algorithm_extension_config_t simulated_piv_alg_cfg;
 static bool simulated_piv_alg_cfg_valid;
+static uint8_t simulated_kbd_layout_id;
+static uint8_t simulated_kbd_keymap[ADMIN_KBD_KEYMAP_LENGTH];
+static bool simulated_kbd_keymap_valid;
 
 int admin_vendor_version(const CAPDU *capdu, RAPDU *rapdu) {
   LL = strlen(GIT_REV);
@@ -82,6 +85,31 @@ int admin_platform_serial_write_once(const uint8_t *buf) {
   if (simulated_sn_valid) return -1;
   memcpy(simulated_sn, buf, sizeof(simulated_sn));
   simulated_sn_valid = true;
+  return 0;
+}
+
+int admin_platform_kbd_keymap_write(uint8_t layout_id, const uint8_t *keymap, uint16_t len) {
+  if (len != ADMIN_KBD_KEYMAP_LENGTH) return -1;
+  simulated_kbd_layout_id = layout_id;
+  memcpy(simulated_kbd_keymap, keymap, sizeof(simulated_kbd_keymap));
+  simulated_kbd_keymap_valid = true;
+  return 0;
+}
+
+int admin_platform_kbd_keymap_read(uint8_t *layout_id, uint8_t *keymap, uint16_t len) {
+  if (!simulated_kbd_keymap_valid) return -1;
+  if (layout_id) *layout_id = simulated_kbd_layout_id;
+  if (keymap) {
+    if (len != ADMIN_KBD_KEYMAP_LENGTH) return -1;
+    memcpy(keymap, simulated_kbd_keymap, sizeof(simulated_kbd_keymap));
+  }
+  return 0;
+}
+
+int admin_platform_kbd_keymap_clear(void) {
+  memset(simulated_kbd_keymap, 0, sizeof(simulated_kbd_keymap));
+  simulated_kbd_layout_id = 0;
+  simulated_kbd_keymap_valid = false;
   return 0;
 }
 

--- a/virt-card/fabrication.c
+++ b/virt-card/fabrication.c
@@ -134,7 +134,7 @@ int card_fabrication_procedure(const char *lfs_root) {
   if (card_fs_init(lfs_root)) return 1;
   init_apdu_buffer();
   device_init();
-  applets_install();
+  if (applets_install() < 0) return 1;
 
   // reset state of applets
   uint8_t c_buf[1024] = "RESET", r_buf[1024];
@@ -157,6 +157,6 @@ int card_fabrication_procedure(const char *lfs_root) {
 int card_read(const char *lfs_root) {
   if (card_fs_init(lfs_root)) return 1;
   init_apdu_buffer();
-  applets_install();
+  if (applets_install() < 0) return 1;
   return 0;
 }

--- a/virt-card/fido-hid-over-udp.c
+++ b/virt-card/fido-hid-over-udp.c
@@ -152,7 +152,7 @@ static void emulate_reboot(void) {
   testmode_set_initial_ticks(0);
   testmode_set_initial_ticks(device_get_tick());
   ctap_schedule_runtime_reset();
-  applets_install();
+  if (applets_install() < 0) exit(1);
 }
 
 static int handle_udp_control_packet(const uint8_t *buf, int length) {

--- a/virt-card/ifdhandler.c
+++ b/virt-card/ifdhandler.c
@@ -129,7 +129,7 @@ RESPONSECODE IFDHPowerICC(DWORD Lun, DWORD Action, PUCHAR Atr, PDWORD AtrLength)
   if (Action == IFD_POWER_UP || Action == IFD_RESET) {
     init_apdu_buffer();
     device_init();
-    applets_install();
+    if (applets_install() < 0) return IFD_COMMUNICATION_ERROR;
     *AtrLength = sizeof(ATR);
     memcpy(Atr, ATR, *AtrLength);
   } else if (Action == IFD_POWER_DOWN) {


### PR DESCRIPTION
## Summary

This PR moves the platform-backed persistent configuration contract into core through platform hooks, so core owns the configuration semantics while the platform can store the records in its reserved flash block.

It covers:
- device configuration flags for LED default state, NDEF enablement, and WebUSB landing-page enablement
- one-time serial storage exposed through existing OpenPGP, PIV, OATH, and USB descriptor paths
- CTAP persistent options and SM2 configuration via platform-backed records
- PIV algorithm-extension configuration via platform-backed records
- host-managed KBDHID ASCII keymap storage for non-QWERTY layouts
- virt-card implementations of the new platform hooks for tests

## Root Cause / Motivation

Some settings were still tied to core-local persistence or hard-coded tables, which made the flash-backed configuration area hard to use cleanly and kept platform-specific storage concerns leaking into applet behavior. Keyboard ASCII translation also needed a configurable keymap so layouts such as Dvorak do not require hard-coded QWERTY mappings.

The PIV integration test failure was caused by `piv_install(1)` resetting the platform algorithm-extension record to defaults. Provisioning tools can reset PIV before use, so admin-selected algorithm IDs such as `ed25519 = 0x22` must survive a PIV reset.

## Implementation Notes

Core now uses weak platform hooks for the persistent records and keeps no LittleFS fallback for the migrated device configuration. The hooks keep core decoupled from the flash address/layout while still allowing the platform to implement the 512-byte flash block policy.

PIV algorithm-extension storage remains the install completion marker, but valid existing platform config is preserved across reset. A regression test verifies that a custom algorithm-extension record survives `piv_install(1)` and can still be used to generate an ED25519 key.

NDEF read-only state is intentionally not moved into platform configuration; it stays represented by the NDEF CC write flag.

## Validation

- `cmake --build build -j8`
- `ctest --test-dir build -R piv --output-on-failure`
- `ctest --test-dir build --output-on-failure`
- GitHub Actions `tests` passed: https://github.com/canokeys/canokey-core/actions/runs/26432190501
