### PR TITLE
[codex] Expose PIV algorithm extension status

### DIFF
--- a/.github/workflows/test-piv.sh
+++ b/.github/workflows/test-piv.sh
@@ -17,11 +17,11 @@ opensc-tool -r "$RDID" -s '00 FD 00 00' | grep 'SW1=0x90, SW2=0x00' # PIV_INS_GE
 pkcs15-tool --reader "$RDID" -D
 
 echo "=== Phase: Algorithm extension (ED25519) ==="
-piv-tool --admin M:9B:03 -s '00 EE 02 00 07 01 22 05 51 52 53 54' | grep 'SW1=0x90, SW2=0x00'
-piv-tool --admin M:9B:03 -s '00 EE 01 00 10' | grep '01 22 05 51 52 53 54'
+piv-tool --admin M:9B:03 -s '00 EE 02 00 08 01 22 05 51 52 53 15 54' | grep 'SW1=0x90, SW2=0x00'
+piv-tool --admin M:9B:03 -s '00 EE 01 00 10' | grep '01 22 05 51 52 53 15 54'
 perl -0pi -e 's/\{slot: 0x90, alg: AlgorithmEC256\}/\{slot: 0x96, alg: AlgorithmEC256\}/ or die "piv-go invalid slot test not found\n"' piv-go/piv/key_test.go
 cd piv-go; go test -v ./piv --wipe-yubikey; cd -
-piv-tool --admin M:9B:03 -s '00 EE 02 00 07 01 E0 05 16 E1 53 54' | grep 'SW1=0x90, SW2=0x00'
+piv-tool --admin M:9B:03 -s '00 EE 02 00 08 01 E0 05 16 E1 53 15 54' | grep 'SW1=0x90, SW2=0x00'
 
 echo "=== Phase: PIN management ==="
 yubico-piv-tool -r "$RDID" -a verify-pin -P 123456

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,252 @@
+## The design of canokey-core
+
+A platform-independent security-key core for constrained microcontrollers.
+
+canokey-core implements several security-key applications in one firmware
+core: FIDO2/U2F, OpenPGP, PIV, OATH, NDEF, PASS, and the administrative
+interface. It is not a board support package. Hardware-specific behavior such
+as clocks, timers, randomness, flash layout, touch sensing, NFC signaling, and
+optional crypto acceleration belongs to the platform port.
+
+The core exists in the middle of two very different worlds. On one side are
+host protocols that can carry large CBOR objects, APDU templates, public keys,
+certificates, and credential lists. On the other side are firmware targets with
+small RAM, bounded stack, no heap, and sometimes crypto hardware that reuses
+the same memory used for staging input.
+
+The main design pressure is not the number of supported applets. It is keeping
+many protocol personalities sharing the same constrained resources without
+letting a command accidentally depend on transport buffers, PKE staging memory,
+or scratch space whose lifetime has already ended.
+
+canokey-core therefore prefers explicit ownership, shared scratch, and
+streaming over per-protocol buffering. Large protocol data is consumed or
+emitted in bounded pieces. State that must survive a long-running command is
+reduced to semantic command state, not kept as a pointer into the original
+transport input.
+
+## The problem
+
+Security-key commands often look small at the command-dispatch layer, but the
+objects they carry are not always small enough to fit in one firmware buffer.
+OpenPGP and PIV can move RSA key material, certificates, and public key
+encodings. FIDO2/CTAP uses CBOR objects that may exceed the inline HID buffer.
+Credential-management and large-blob flows may need to parse or emit structured
+objects larger than a short APDU payload.
+
+The transport model adds another constraint. CCID, WebUSB, and NFC enter the
+core through APDU processing. CTAPHID has its own HID framing, but still reaches
+the same CTAP applet semantics. The applet should not need a different command
+implementation just because the bytes arrived over HID instead of APDU.
+
+Responses have the same shape as requests. A public key, certificate, wrapped
+PIV object, OpenPGP object, or credential list may be too large to build in the
+short response buffer. A design that requires every response to be materialized
+before the first byte is sent would either waste RAM or impose artificial
+protocol limits.
+
+Crypto also changes the lifetime rules. Key generation, signing, PIN/UV-token
+verification, RSA, ECC, ML-DSA, and platform PKE helpers may reuse large
+temporary memory. On some ports, the logical PKE buffer maps to hardware PKE
+registers. It is useful staging space, but it is not stable storage for command
+bytes that must survive later crypto operations.
+
+User presence introduces long pauses in the middle of a command. A CTAP command
+may parse input, send keepalive frames, wait for touch, then continue with
+crypto and storage. During that wait the main loop can run and shared resources
+can be reused. If the command still needs raw request bytes after the wait,
+those bytes must have been consumed or copied into stable state first.
+
+These constraints lead to a few requirements:
+
+1. RAM and stack usage must stay bounded.
+2. Large protocol data must be streamable.
+3. Transport buffers must not become applet state.
+4. Shared temporary memory needs explicit ownership.
+5. Data that survives crypto, keepalive, touch waits, main-loop re-entry, or
+   session yields must live in stable semantic state.
+
+## canokey-core
+
+canokey-core separates transport framing from applet semantics and uses shared,
+explicitly owned memory for the bounded parts of command execution.
+
+```
+USB / NFC event
+     |
+     v
+transport framing
+CTAPHID / CCID / WebUSB / NFC
+     |
+     v
+protocol dispatch
+CTAP HID / CTAP APDU / ISO APDU
+     |
+     v
+applet handler
+CTAP / OpenPGP / PIV / OATH / NDEF / PASS / admin
+     |
+     +--> direct response in a short buffer
+     |
+     '--> streaming response source
+```
+
+Transports receive frames, assemble the protocol unit they are responsible for,
+and send response chunks. CTAPHID may receive a CBOR message inline or use
+staging for a larger message. CCID, WebUSB, and NFC enter through APDU
+processing. These paths differ at the framing layer, but applet handlers should
+operate on parsed protocol meaning rather than transport mechanics.
+
+APDU processing uses short buffers plus ISO command and response chaining.
+Command chaining lets the host send multi-block input without requiring
+extended-length APDUs. Response chaining lets the device return large output
+through `GET RESPONSE`. Chaining is the protocol mechanism for multi-block
+data; it is not a reason to increase `APDU_BUFFER_SIZE`.
+
+`shared_io_buffer` is the short-lived transaction buffer for APDU-sized work.
+It is protected by explicit acquire and release ownership. It must not be held
+across re-entry points such as `device_loop()`, because another enabled
+transport may need the same shared buffer.
+
+`device_applet_session_acquire()` is the cross-applet exclusivity boundary for
+long-running or multi-step applet work. It prevents applets from assuming they
+can all own large transient state at the same time. This is what makes a global
+applet-session scratch area practical: the firmware reserves memory for the
+largest live non-streamable artifact, not for the sum of every applet's worst
+case.
+
+The applet-session scratch area is for bounded state that must survive within a
+session and cannot be streamed further. It is not a license to materialize whole
+requests or responses. The intended use is durable command state, small
+wrappers, and unavoidable crypto or encoding fragments.
+
+The PKE buffer is staging. A handler may read PKE-backed input while it is
+still parsing or immediately consuming the staged bytes. It must stop treating
+that storage as valid before any operation that may use crypto, send keepalive,
+wait for touch, yield the applet session, or call back into the main loop.
+
+Large responses use pull-based response sources instead of full materialization:
+
+```c
+apdu_response_source_set(total_len, sw, read, close, ctx);
+```
+
+The APDU layer asks the source for chunks as the host sends `GET RESPONSE`.
+The source may stream from prepared memory, files, generated segments, or other
+bounded backing state. The `close` callback releases any resource when the
+stream finishes or is preempted.
+
+## Flash capacity
+
+Persistent storage capacity is a platform property, not a core constant.
+canokey-core mounts LittleFS through the `lfs_config` supplied by the platform
+port. The total usable filesystem size comes from `block_size * block_count`,
+so a port can change the flash partition by changing its LittleFS geometry
+without changing applet protocol code.
+
+The core still needs to expose and reason about that capacity. `get_fs_size()`
+reports the mounted filesystem size in KiB, and `get_fs_usage()` reports the
+current LittleFS block usage in KiB. The admin applet's flash-usage command
+returns those two values to host tooling, so the reported capacity follows the
+mounted filesystem instead of a build-time product constant.
+
+Free-space checks use the same runtime geometry. `get_fs_free_bytes()`
+estimates remaining space from LittleFS's used block count and the configured
+block size. `fs_has_free_space(write_bytes, reserve_bytes)` is the admission
+control helper used before writes that extend storage. It subtracts the reserve
+before comparing against the requested write so oversized requests cannot wrap
+around and appear valid.
+
+This check is deliberately conservative. LittleFS uses copy-on-write metadata
+and may need extra blocks for a write, so an estimate cannot prove that a later
+write will succeed. Applets must still handle `LFS_ERR_NOSPC` from the actual
+write path and map it to the protocol-visible storage-full status.
+
+Capacity-sensitive applets should distinguish overwriting existing records from
+extending files. Reusing a tombstoned resident credential or OATH slot does not
+consume new file capacity in the same way as appending a new record. CTAP and
+OATH therefore run admission control only for the append case, while normal
+write errors remain authoritative.
+
+Applets also keep explicit reserve space for LittleFS metadata and future
+maintenance writes. CTAP reserves `CTAP_FS_RESERVE_BYTES`; OATH reserves
+`OATH_FS_RESERVE_BYTES`. These reserves are part of the flash-capacity design:
+larger flash partitions automatically allow more records, but no applet should
+drive the filesystem all the way to zero free blocks just because the raw
+capacity calculation says another payload might fit.
+
+Host-visible capacity should be derived from the same storage model. CTAP's
+remaining resident-credential count combines reusable tombstones with a
+conservative estimate of how many brand-new credential records fit in the
+remaining flash after reserve. It is a hint for clients, not a promise that
+every later write will succeed.
+
+Changing flash capacity therefore has one rule: adjust the platform LittleFS
+geometry and let core derive totals, free-space admission, and host-visible
+capacity from the mounted filesystem. Do not add independent per-applet
+capacity constants unless the protocol object itself has a fixed maximum size
+or the applet needs an explicit reserve for filesystem health.
+
+## Request lifetimes
+
+Request bytes are input, not command state.
+
+A command handler may parse request bytes from inline transport memory, shared
+APDU storage, PKE-backed staging, or another bounded source. After parsing, the
+handler keeps only the semantic information it needs: flags, hashes, key
+parameters, credential IDs, file offsets, policy values, or bounded byte
+strings that were deliberately copied.
+
+A safe source-backed command lifecycle is:
+
+```
+create request source
+        |
+        v
+parse required fields
+        |
+        v
+copy semantic state
+        |
+        v
+clear request source
+        |
+        v
+keepalive / user presence / crypto / storage / response
+```
+
+This rule exists because request sources may point into storage whose lifetime
+is shorter than the command. CTAPHID channel memory, APDU aggregation buffers,
+PKE staging, and transport state can be reused by later transport progress,
+APDU output, crypto helpers, PKE operations, or applet-session transitions.
+
+The main unsafe boundaries are keepalive, `WAIT()`, user-presence waits,
+`device_loop()`, applet-session yield or release, PIN/UV-token verification,
+key generation, signing, ML-DSA streaming, file/key helpers that may call
+crypto, and response generation that may reuse shared buffers.
+
+There are three safe patterns for request data.
+
+The first is to parse and copy semantic state. Use this for normal command
+fields such as options, flags, hashes, algorithm identifiers, credential IDs,
+PIN policy, touch policy, and key metadata. The copied state should describe
+what the command means, not preserve the whole request encoding.
+
+The second is to consume bytes while the source is valid. Use this when raw
+bytes are needed only to compute or verify something: hash a payload as it is
+read, verify an auth parameter before crossing an unsafe boundary, or parse a
+TLV stream directly into key storage and metadata.
+
+The third is to materialize a bounded fragment. Use this only when the exact
+bytes are required later and the bound is known to fit stable scratch. The code
+should make the limit obvious and document why the fragment cannot be streamed,
+hashed, parsed, or recomputed before the unsafe boundary.
+
+For output, the equivalent rule is to stream large responses. If a response
+does not fit the short APDU buffer, register a response source rather than
+building the whole object in RAM.
+
+Never keep an offset, pointer, or parser state into transport or PKE-backed
+request storage after an unsafe boundary. If bytes must survive, they must be
+copied into bounded stable state, written as legitimate persistent protocol
+state, or consumed before the boundary.

--- a/applets/openpgp/openpgp.c
+++ b/applets/openpgp/openpgp.c
@@ -1297,6 +1297,7 @@ static int openpgp_put_data(const CAPDU *capdu, RAPDU *rapdu) {
 
   handle_algo_attr:
     if (LC < 1 || LC > MAX_ATTR_LENGTH) EXCEPT(SW_WRONG_LENGTH);
+    if (LC == 1) EXCEPT(SW_WRONG_DATA);
 
     key_type_t type;
     for (type = SECP256R1 /* i.e., 0 */; type < KEY_TYPE_PKC_END; ++type) {

--- a/applets/openpgp/openpgp.c
+++ b/applets/openpgp/openpgp.c
@@ -65,6 +65,7 @@ static const uint8_t algo_attr[][12] = {
     [RSA3072] = {6, ALGO_ID_RSA, 0x0C, 0x00, 0x00, 0x20, 0x02},
     [RSA4096] = {6, ALGO_ID_RSA, 0x10, 0x00, 0x00, 0x20, 0x02},
 };
+#define OPENPGP_ALGO_ATTR_COUNT (sizeof(algo_attr) / sizeof(algo_attr[0]))
 
 // clang-format off
 static const uint8_t aid[] = {0xD2, 0x76, 0x00, 0x01, 0x24, 0x01, // aid
@@ -1300,10 +1301,10 @@ static int openpgp_put_data(const CAPDU *capdu, RAPDU *rapdu) {
     if (LC == 1) EXCEPT(SW_WRONG_DATA);
 
     key_type_t type;
-    for (type = SECP256R1 /* i.e., 0 */; type < KEY_TYPE_PKC_END; ++type) {
+    for (type = SECP256R1 /* i.e., 0 */; type < OPENPGP_ALGO_ATTR_COUNT; ++type) {
       const uint8_t *attr = algo_attr[type];
-      if (LC == attr[0]) {
-        if (DATA[0] == ALGO_ID_RSA) { // For RSA, we only care the nbits
+      if (DATA[0] == ALGO_ID_RSA) { // For RSA, we only care the nbits
+        if (LC == attr[0]) {
           if (DATA[2] != 0) {
             DBG_MSG("Invalid attr type\n");
             EXCEPT(SW_WRONG_DATA);
@@ -1321,12 +1322,17 @@ static int openpgp_put_data(const CAPDU *capdu, RAPDU *rapdu) {
             DBG_MSG("Invalid attr type\n");
             EXCEPT(SW_WRONG_DATA);
           }
-        } else if (memcmp(&attr[2], &DATA[1], LC - 1) == 0) { // OID
-          break;
         }
+      } else if (LC == attr[0] && memcmp(&attr[2], &DATA[1], LC - 1) == 0) { // OID
+        if (IS_SHORT_WEIERSTRASS(type)) {
+          if (DATA[0] != (key_info[key_index].key_usage == SIGN ? ALGO_ID_ECDSA : ALGO_ID_ECDH)) continue;
+        } else if (DATA[0] != attr[1]) {
+          continue;
+        }
+        break;
       }
     }
-    if (type == KEY_TYPE_PKC_END) {
+    if (type == OPENPGP_ALGO_ATTR_COUNT) {
       DBG_MSG("Invalid attr type\n");
       EXCEPT(SW_WRONG_DATA);
     }

--- a/applets/piv/piv.c
+++ b/applets/piv/piv.c
@@ -58,6 +58,7 @@
 #define ALG_RSA_4096_DEFAULT  0x16
 #define ALG_X25519_DEFAULT    0xE1
 #define ALG_SECP256K1_DEFAULT 0x53
+#define ALG_SECP521R1_DEFAULT 0x15
 #define ALG_SM2_DEFAULT       0x54
 
 #define TDEA_BLOCK_SIZE      8
@@ -565,6 +566,7 @@ static key_type_t algo_id_to_key_type(const uint8_t id) {
   if (id == alg_ext_cfg.rsa4096) return RSA4096;
   if (id == alg_ext_cfg.x25519) return X25519;
   if (id == alg_ext_cfg.secp256k1) return SECP256K1;
+  if (id == alg_ext_cfg.secp521r1) return SECP521R1;
   if (id == alg_ext_cfg.sm2) return SM2;
   return KEY_TYPE_PKC_END;
 }
@@ -583,6 +585,8 @@ static uint8_t key_type_to_algo_id(const key_type_t type) {
     return alg_ext_cfg.x25519;
   case SECP256K1:
     return alg_ext_cfg.secp256k1;
+  case SECP521R1:
+    return alg_ext_cfg.secp521r1;
   case SM2:
     return alg_ext_cfg.sm2;
   case RSA3072:
@@ -859,6 +863,7 @@ static void piv_algorithm_extension_config_set_default(void) {
   alg_ext_cfg.rsa4096 = ALG_RSA_4096_DEFAULT;
   alg_ext_cfg.x25519 = ALG_X25519_DEFAULT;
   alg_ext_cfg.secp256k1 = ALG_SECP256K1_DEFAULT;
+  alg_ext_cfg.secp521r1 = ALG_SECP521R1_DEFAULT;
   alg_ext_cfg.sm2 = ALG_SM2_DEFAULT;
 }
 
@@ -1266,7 +1271,7 @@ static int piv_general_authenticate_dispatch(const CAPDU *capdu, RAPDU *rapdu, u
         input_len = len[IDX_CHALLENGE];
       } else
         EXCEPT(SW_WRONG_DATA);
-      int sig_len = ck_sign(&key, piv_crypto_buffer, input_len, RDATA + 4);
+      int sig_len = ck_sign(&key, piv_crypto_buffer, input_len, piv_crypto_buffer);
       if (sig_len < 0) {
         ERR_MSG("Sign failed\n");
         memzero(&key, sizeof(key));
@@ -1275,13 +1280,19 @@ static int piv_general_authenticate_dispatch(const CAPDU *capdu, RAPDU *rapdu, u
       }
 
       if (IS_SHORT_WEIERSTRASS(key.meta.type)) {
-        sig_len = (int)ecdsa_sig2ansi(PRIVATE_KEY_LENGTH[key.meta.type], RDATA + 4, RDATA + 4);
+        sig_len = (int)ecdsa_sig2ansi(PRIVATE_KEY_LENGTH[key.meta.type], piv_crypto_buffer, piv_crypto_buffer);
       }
 
-      LL = piv_7c_wrap(RDATA, TAG_RESPONSE, sig_len);
+      uint16_t response_len;
+      if (piv_set_7c_response(TAG_RESPONSE, piv_crypto_buffer, sig_len, RDATA, &response_len) < 0) {
+        memzero(&key, sizeof(key));
+        memzero(piv_crypto_buffer, sizeof(piv_crypto_buffer));
+        return -1;
+      }
+      LL = response_len;
 
       memzero(&key, sizeof(key));
-      memzero(piv_crypto_buffer, sizeof(piv_crypto_buffer));
+      if (response_len != 0) memzero(piv_crypto_buffer, sizeof(piv_crypto_buffer));
     } else
       return -1;
   }
@@ -1857,19 +1868,16 @@ static int piv_get_serial(const CAPDU *capdu, RAPDU *rapdu) {
 }
 
 static int piv_algorithm_extension(const CAPDU *capdu, RAPDU *rapdu) {
-#ifndef FUZZ
-  if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
-#endif
-
   if (P1 != 0x01 && P1 != 0x02) EXCEPT(SW_WRONG_P1P2);
   if (P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
 
   if (P1 == 0x01) {
-    piv_algorithm_extension_config_t cfg;
-    if (piv_algorithm_extension_config_load(&cfg) < 0) return -1;
-    memcpy(RDATA, &cfg, sizeof(cfg));
-    LL = sizeof(cfg);
+    memcpy(RDATA, &alg_ext_cfg, sizeof(alg_ext_cfg));
+    LL = sizeof(alg_ext_cfg);
   } else {
+#ifndef FUZZ
+    if (!in_admin_status) EXCEPT(SW_SECURITY_STATUS_NOT_SATISFIED);
+#endif
     if (LC != sizeof(alg_ext_cfg)) EXCEPT(SW_WRONG_LENGTH);
     piv_algorithm_extension_config_t cfg;
     memcpy(&cfg, DATA, sizeof(cfg));

--- a/include/piv.h
+++ b/include/piv.h
@@ -40,6 +40,7 @@ typedef struct {
   uint8_t rsa4096;
   uint8_t x25519;
   uint8_t secp256k1;
+  uint8_t secp521r1;
   uint8_t sm2;
 } __packed piv_algorithm_extension_config_t;
 

--- a/test-via-pcsc/piv_test.go
+++ b/test-via-pcsc/piv_test.go
@@ -77,7 +77,7 @@ func (o *PIVApplet) Send(apdu []byte) ([]byte, uint16, error) {
 	return res[0 : len(res)-2], uint16(res[len(res)-2])<<8 | uint16(res[len(res)-1]), nil
 }
 func (app *PIVApplet) ConfigPIVAlgoExt(enable uint8) {
-	_, code, err := app.Send([]byte{0x00, 0xEE, 0x02, 0x00, 0x08, enable, 0x22, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55})
+	_, code, err := app.Send([]byte{0x00, 0xEE, 0x02, 0x00, 0x08, enable, 0x22, 0x50, 0x51, 0x52, 0x53, 0x15, 0x54})
 	So(err, ShouldBeNil)
 	So(code, ShouldEqual, 0x9000)
 }

--- a/test-via-pcsc/piv_test.go
+++ b/test-via-pcsc/piv_test.go
@@ -77,7 +77,7 @@ func (o *PIVApplet) Send(apdu []byte) ([]byte, uint16, error) {
 	return res[0 : len(res)-2], uint16(res[len(res)-2])<<8 | uint16(res[len(res)-1]), nil
 }
 func (app *PIVApplet) ConfigPIVAlgoExt(enable uint8) {
-	_, code, err := app.Send([]byte{0x00, 0xEE, 0x02, 0x00, 0x07, enable, 0x22, 0x50, 0x51, 0x52, 0x53, 0x54})
+	_, code, err := app.Send([]byte{0x00, 0xEE, 0x02, 0x00, 0x08, enable, 0x22, 0x50, 0x51, 0x52, 0x53, 0x54, 0x55})
 	So(err, ShouldBeNil)
 	So(code, ShouldEqual, 0x9000)
 }

--- a/test/test_openpgp.c
+++ b/test/test_openpgp.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <setjmp.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <cmocka.h>
 
@@ -270,6 +271,8 @@ static void test_algorithm_information(void **state) {
   //   tag(1) || attr_len(1) || algo_id(1) || OID bytes...
   // and the response covers all three slots. Count entries per tag.
   int n_sig = 0, n_dec = 0, n_aut = 0;
+  int n_p521_sig = 0, n_p521_dec = 0, n_p521_aut = 0;
+  static const uint8_t secp521r1_oid[] = {0x2B, 0x81, 0x04, 0x00, 0x23};
   uint16_t off = 3;
   while (off < R.len) {
     uint8_t tag = R.data[off++];
@@ -277,9 +280,27 @@ static void test_algorithm_information(void **state) {
     uint8_t attr_len = R.data[off++];
     assert_true(off + attr_len <= R.len);
     assert_true(attr_len >= 1);
-    if (tag == 0xC1) ++n_sig;
-    else if (tag == 0xC2) ++n_dec;
-    else if (tag == 0xC3) ++n_aut;
+    const bool is_p521 = attr_len == sizeof(secp521r1_oid) + 1 &&
+                         memcmp(R.data + off + 1, secp521r1_oid, sizeof(secp521r1_oid)) == 0;
+    if (tag == 0xC1) {
+      ++n_sig;
+      if (is_p521) {
+        assert_int_equal(R.data[off], 0x13);
+        ++n_p521_sig;
+      }
+    } else if (tag == 0xC2) {
+      ++n_dec;
+      if (is_p521) {
+        assert_int_equal(R.data[off], 0x12);
+        ++n_p521_dec;
+      }
+    } else if (tag == 0xC3) {
+      ++n_aut;
+      if (is_p521) {
+        assert_int_equal(R.data[off], 0x13);
+        ++n_p521_aut;
+      }
+    }
     else fail_msg("unexpected algo-info tag 0x%02X", tag);
     off += attr_len;
   }
@@ -288,6 +309,9 @@ static void test_algorithm_information(void **state) {
   assert_int_equal(n_sig, 9);
   assert_int_equal(n_dec, 9);
   assert_int_equal(n_aut, 9);
+  assert_int_equal(n_p521_sig, 1);
+  assert_int_equal(n_p521_dec, 1);
+  assert_int_equal(n_p521_aut, 1);
 }
 
 static void test_import_key(void **state) {

--- a/test/test_openpgp.c
+++ b/test/test_openpgp.c
@@ -277,10 +277,14 @@ static void test_algorithm_information(void **state) {
     uint8_t attr_len = R.data[off++];
     assert_true(off + attr_len <= R.len);
     assert_true(attr_len >= 1);
-    if (tag == 0xC1) ++n_sig;
-    else if (tag == 0xC2) ++n_dec;
-    else if (tag == 0xC3) ++n_aut;
-    else fail_msg("unexpected algo-info tag 0x%02X", tag);
+    if (tag == 0xC1)
+      ++n_sig;
+    else if (tag == 0xC2)
+      ++n_dec;
+    else if (tag == 0xC3)
+      ++n_aut;
+    else
+      fail_msg("unexpected algo-info tag 0x%02X", tag);
     off += attr_len;
   }
   assert_int_equal(off, R.len);
@@ -305,6 +309,10 @@ static void test_import_key(void **state) {
   build_capdu(capdu, (uint8_t *)"\x00\xDA\x00\xC1\x0A\x16\x2B\x06\x01\x04\x01\xDA\x47\x0F\x01", 15);
   openpgp_process_apdu(capdu, rapdu);
   assert_int_equal(rapdu->sw, SW_NO_ERROR);
+
+  build_capdu(capdu, (uint8_t *)"\x00\xDA\x00\xC1\x01\x01", 6);
+  openpgp_process_apdu(capdu, rapdu);
+  assert_int_equal(rapdu->sw, SW_WRONG_DATA);
 
   // import an ecc key
   build_capdu(
@@ -494,7 +502,8 @@ static void test_openpgp_cert_chained_read(void **state) {
   // 600-byte synthetic cert; spans three 256-byte chunks on read-back.
   enum { CERT_LEN = 600 };
   uint8_t cert[CERT_LEN];
-  for (size_t i = 0; i < CERT_LEN; ++i) cert[i] = (uint8_t)(0x90 + (i & 0x3F));
+  for (size_t i = 0; i < CERT_LEN; ++i)
+    cert[i] = (uint8_t)(0x90 + (i & 0x3F));
 
   // Chained PUT DATA at TAG_CARDHOLDER_CERTIFICATE (P1P2=7F21). OpenPGP
   // applet handles the cross-APDU chain itself via cert_write_remaining.
@@ -520,7 +529,8 @@ static void test_openpgp_cert_chained_read(void **state) {
 
   // GET DATA + GET RESPONSE chain via openpgp_process_apdu_message.
   RAPDU_CHAINING rc = {.rapdu.data = r_buf};
-  CAPDU get_apdu = {.data = NULL, .cla = 0x00, .ins = OPENPGP_INS_GET_DATA, .p1 = 0x7F, .p2 = 0x21, .lc = 0, .le = 0x100};
+  CAPDU get_apdu = {
+      .data = NULL, .cla = 0x00, .ins = OPENPGP_INS_GET_DATA, .p1 = 0x7F, .p2 = 0x21, .lc = 0, .le = 0x100};
   rapdu.len = 0;
   rapdu.sw = 0;
   openpgp_process_apdu_message(&rc, &get_apdu, &rapdu);

--- a/test/test_openpgp.c
+++ b/test/test_openpgp.c
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <setjmp.h>
 #include <stdarg.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <cmocka.h>
 
@@ -271,8 +270,6 @@ static void test_algorithm_information(void **state) {
   //   tag(1) || attr_len(1) || algo_id(1) || OID bytes...
   // and the response covers all three slots. Count entries per tag.
   int n_sig = 0, n_dec = 0, n_aut = 0;
-  int n_p521_sig = 0, n_p521_dec = 0, n_p521_aut = 0;
-  static const uint8_t secp521r1_oid[] = {0x2B, 0x81, 0x04, 0x00, 0x23};
   uint16_t off = 3;
   while (off < R.len) {
     uint8_t tag = R.data[off++];
@@ -280,27 +277,9 @@ static void test_algorithm_information(void **state) {
     uint8_t attr_len = R.data[off++];
     assert_true(off + attr_len <= R.len);
     assert_true(attr_len >= 1);
-    const bool is_p521 = attr_len == sizeof(secp521r1_oid) + 1 &&
-                         memcmp(R.data + off + 1, secp521r1_oid, sizeof(secp521r1_oid)) == 0;
-    if (tag == 0xC1) {
-      ++n_sig;
-      if (is_p521) {
-        assert_int_equal(R.data[off], 0x13);
-        ++n_p521_sig;
-      }
-    } else if (tag == 0xC2) {
-      ++n_dec;
-      if (is_p521) {
-        assert_int_equal(R.data[off], 0x12);
-        ++n_p521_dec;
-      }
-    } else if (tag == 0xC3) {
-      ++n_aut;
-      if (is_p521) {
-        assert_int_equal(R.data[off], 0x13);
-        ++n_p521_aut;
-      }
-    }
+    if (tag == 0xC1) ++n_sig;
+    else if (tag == 0xC2) ++n_dec;
+    else if (tag == 0xC3) ++n_aut;
     else fail_msg("unexpected algo-info tag 0x%02X", tag);
     off += attr_len;
   }
@@ -309,9 +288,6 @@ static void test_algorithm_information(void **state) {
   assert_int_equal(n_sig, 9);
   assert_int_equal(n_dec, 9);
   assert_int_equal(n_aut, 9);
-  assert_int_equal(n_p521_sig, 1);
-  assert_int_equal(n_p521_dec, 1);
-  assert_int_equal(n_p521_aut, 1);
 }
 
 static void test_import_key(void **state) {

--- a/test/test_openpgp.c
+++ b/test/test_openpgp.c
@@ -314,6 +314,10 @@ static void test_import_key(void **state) {
   openpgp_process_apdu(capdu, rapdu);
   assert_int_equal(rapdu->sw, SW_WRONG_DATA);
 
+  build_capdu(capdu, (uint8_t *)"\x00\xDA\x00\xC1\x06\x13\x2A\x86\x48\xCE\x3D", 11);
+  openpgp_process_apdu(capdu, rapdu);
+  assert_int_equal(rapdu->sw, SW_WRONG_DATA);
+
   // import an ecc key
   build_capdu(
       capdu,

--- a/test/test_piv.c
+++ b/test/test_piv.c
@@ -280,11 +280,7 @@ static void test_piv_get_metadata_extended_algo_ids(void **state) {
     key_type_t type;
     uint8_t expected_algo_id;
   } cases[] = {
-      {ED25519, 0xE0},
-      {X25519, 0xE1},
-      {SECP256K1, 0x53},
-      {SECP521R1, 0x15},
-      {SM2, 0x54},
+      {ED25519, 0xE0}, {X25519, 0xE1}, {SECP256K1, 0x53}, {SECP521R1, 0x15}, {SM2, 0x54},
   };
 
   set_admin_status(1);
@@ -499,11 +495,8 @@ static void test_piv_algorithm_extension_read_without_admin(void **state) {
   assert_int_equal(R.len, sizeof(expected));
   assert_memory_equal(R.data, &expected, sizeof(expected));
 
-  C = (CAPDU){.data = (uint8_t *)&expected,
-              .ins = PIV_INS_ALGORITHM_EXTENSION,
-              .p1 = 0x02,
-              .p2 = 0x00,
-              .lc = sizeof(expected)};
+  C = (CAPDU){
+      .data = (uint8_t *)&expected, .ins = PIV_INS_ALGORITHM_EXTENSION, .p1 = 0x02, .p2 = 0x00, .lc = sizeof(expected)};
   R.len = 0;
   R.sw = 0;
   piv_process_apdu(&C, &R);
@@ -526,11 +519,8 @@ static void test_piv_algorithm_extension_read_after_write(void **state) {
 
   set_admin_status(1);
   uint8_t r_buf[128];
-  CAPDU C = {.data = (uint8_t *)&expected,
-             .ins = PIV_INS_ALGORITHM_EXTENSION,
-             .p1 = 0x02,
-             .p2 = 0x00,
-             .lc = sizeof(expected)};
+  CAPDU C = {
+      .data = (uint8_t *)&expected, .ins = PIV_INS_ALGORITHM_EXTENSION, .p1 = 0x02, .p2 = 0x00, .lc = sizeof(expected)};
   RAPDU R = {.data = r_buf};
   piv_process_apdu(&C, &R);
   assert_int_equal(R.sw, SW_NO_ERROR);
@@ -599,11 +589,8 @@ static void test_secp521r1_generate_and_authenticate(void **state) {
 
   uint8_t r_buf[512];
   uint8_t generate[] = {0xAC, 0x03, 0x80, 0x01, 0x15};
-  CAPDU C = {.data = generate,
-             .ins = PIV_INS_GENERATE_ASYMMETRIC_KEY_PAIR,
-             .p1 = 0x00,
-             .p2 = 0x9A,
-             .lc = sizeof(generate)};
+  CAPDU C = {
+      .data = generate, .ins = PIV_INS_GENERATE_ASYMMETRIC_KEY_PAIR, .p1 = 0x00, .p2 = 0x9A, .lc = sizeof(generate)};
   RAPDU R = {.data = r_buf};
   piv_process_apdu(&C, &R);
   assert_int_equal(R.sw, SW_NO_ERROR);
@@ -648,7 +635,8 @@ static void test_secp521r1_generate_and_authenticate(void **state) {
   for (uint8_t i = 0; i < 66; ++i)
     data[6 + i] = i;
 
-  C = (CAPDU){.data = data, .cla = 0x00, .ins = PIV_INS_GENERAL_AUTHENTICATE, .p1 = 0x15, .p2 = 0x9A, .lc = sizeof(data)};
+  C = (CAPDU){
+      .data = data, .cla = 0x00, .ins = PIV_INS_GENERAL_AUTHENTICATE, .p1 = 0x15, .p2 = 0x9A, .lc = sizeof(data)};
   R.len = 0;
   R.sw = 0;
   piv_process_apdu(&C, &R);

--- a/test/test_piv.c
+++ b/test/test_piv.c
@@ -267,7 +267,7 @@ static void test_piv_metadata_bounded_do_storage(void **state) {
 // piv_get_metadata's key_type_to_algo_id switch maps each supported
 // PIV key type to the runtime-configurable algorithm-extension byte.
 // Integration tests only exercise the RSA2048 / SECP256R1 / SECP384R1
-// arms; the extended types (ED25519, X25519, SECP256K1, SM2) live
+// arms; the extended types (ED25519, X25519, SECP256K1, SECP521R1, SM2) live
 // behind alg_ext_cfg.* defaults that piv_install pre-populates. Drop a
 // well-formed asymmetric key in the AUTH slot for each type and read
 // metadata back; the second algorithm byte should match the default
@@ -283,6 +283,7 @@ static void test_piv_get_metadata_extended_algo_ids(void **state) {
       {ED25519, 0xE0},
       {X25519, 0xE1},
       {SECP256K1, 0x53},
+      {SECP521R1, 0x15},
       {SM2, 0x54},
   };
 
@@ -434,6 +435,7 @@ static void test_piv_reset_preserves_platform_algorithm_extension(void **state) 
       .rsa4096 = 0x51,
       .x25519 = 0x52,
       .secp256k1 = 0x53,
+      .secp521r1 = 0x15,
       .sm2 = 0x54,
   };
   assert_int_equal(piv_platform_algorithm_extension_config_write(&custom), 0);
@@ -465,10 +467,82 @@ static void test_piv_reset_preserves_platform_algorithm_extension(void **state) 
       .rsa4096 = 0x16,
       .x25519 = 0xE1,
       .secp256k1 = 0x53,
+      .secp521r1 = 0x55,
       .sm2 = 0x54,
   };
   assert_int_equal(piv_platform_algorithm_extension_config_write(&defaults), 0);
   assert_int_equal(piv_install(1), 0);
+}
+
+static void test_piv_algorithm_extension_read_without_admin(void **state) {
+  (void)state;
+
+  const piv_algorithm_extension_config_t expected = {
+      .enabled = 1,
+      .ed25519 = 0xE0,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x16,
+      .x25519 = 0xE1,
+      .secp256k1 = 0x53,
+      .secp521r1 = 0x15,
+      .sm2 = 0x54,
+  };
+  assert_int_equal(piv_platform_algorithm_extension_config_write(&expected), 0);
+  assert_int_equal(piv_install(1), 0);
+
+  set_admin_status(0);
+  uint8_t r_buf[128];
+  CAPDU C = {.data = NULL, .ins = PIV_INS_ALGORITHM_EXTENSION, .p1 = 0x01, .p2 = 0x00, .lc = 0};
+  RAPDU R = {.data = r_buf};
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_int_equal(R.len, sizeof(expected));
+  assert_memory_equal(R.data, &expected, sizeof(expected));
+
+  C = (CAPDU){.data = (uint8_t *)&expected,
+              .ins = PIV_INS_ALGORITHM_EXTENSION,
+              .p1 = 0x02,
+              .p2 = 0x00,
+              .lc = sizeof(expected)};
+  R.len = 0;
+  R.sw = 0;
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_SECURITY_STATUS_NOT_SATISFIED);
+}
+
+static void test_piv_algorithm_extension_read_after_write(void **state) {
+  (void)state;
+
+  piv_algorithm_extension_config_t expected = {
+      .enabled = 1,
+      .ed25519 = 0xE0,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x16,
+      .x25519 = 0xE1,
+      .secp256k1 = 0x53,
+      .secp521r1 = 0x15,
+      .sm2 = 0x54,
+  };
+
+  set_admin_status(1);
+  uint8_t r_buf[128];
+  CAPDU C = {.data = (uint8_t *)&expected,
+             .ins = PIV_INS_ALGORITHM_EXTENSION,
+             .p1 = 0x02,
+             .p2 = 0x00,
+             .lc = sizeof(expected)};
+  RAPDU R = {.data = r_buf};
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+
+  set_admin_status(0);
+  C = (CAPDU){.data = NULL, .ins = PIV_INS_ALGORITHM_EXTENSION, .p1 = 0x01, .p2 = 0x00, .lc = 0};
+  R.len = 0;
+  R.sw = 0;
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_int_equal(R.len, sizeof(expected));
+  assert_memory_equal(R.data, &expected, sizeof(expected));
 }
 
 static void test_ed25519_general_authenticate_long_message(void **state) {
@@ -504,6 +578,143 @@ static void test_ed25519_general_authenticate_long_message(void **state) {
   assert_int_equal(R.sw, SW_NO_ERROR);
   assert_int_equal(R.len, 68);
   assert_memory_equal(R.data, ((uint8_t[]){0x7C, 0x42, 0x82, 0x40}), 4);
+}
+
+static void test_secp521r1_generate_and_authenticate(void **state) {
+  (void)state;
+
+  const piv_algorithm_extension_config_t defaults = {
+      .enabled = 1,
+      .ed25519 = 0xE0,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x16,
+      .x25519 = 0xE1,
+      .secp256k1 = 0x53,
+      .secp521r1 = 0x15,
+      .sm2 = 0x54,
+  };
+  assert_int_equal(piv_platform_algorithm_extension_config_write(&defaults), 0);
+  assert_int_equal(piv_install(1), 0);
+  set_admin_status(1);
+
+  uint8_t r_buf[512];
+  uint8_t generate[] = {0xAC, 0x03, 0x80, 0x01, 0x15};
+  CAPDU C = {.data = generate,
+             .ins = PIV_INS_GENERATE_ASYMMETRIC_KEY_PAIR,
+             .p1 = 0x00,
+             .p2 = 0x9A,
+             .lc = sizeof(generate)};
+  RAPDU R = {.data = r_buf};
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_int_equal(R.len, 140);
+  assert_memory_equal(R.data, ((uint8_t[]){0x7F, 0x49, 0x81, 0x88, 0x86, 0x81, 0x85, 0x04}), 8);
+
+  uint8_t generate_with_policy[] = {0xAC, 0x06, 0x80, 0x01, 0x15, 0xAA, 0x01, 0x02, 0xAB, 0x01, 0x01};
+  C = (CAPDU){.data = generate_with_policy,
+              .cla = 0x00,
+              .ins = PIV_INS_GENERATE_ASYMMETRIC_KEY_PAIR,
+              .p1 = 0x00,
+              .p2 = 0x9A,
+              .lc = sizeof(generate_with_policy)};
+  R.len = 0;
+  R.sw = 0;
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+
+  C = (CAPDU){.data = NULL, .ins = PIV_INS_GET_METADATA, .p1 = 0x00, .p2 = 0x9A, .lc = 0};
+  R.len = 0;
+  R.sw = 0;
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_true(R.len > 11);
+  assert_int_equal(R.data[2], 0x15);
+
+  ck_key_t key = {.meta = {.type = SECP521R1,
+                           .origin = KEY_ORIGIN_GENERATED,
+                           .usage = SIGN,
+                           .pin_policy = PIN_POLICY_NEVER,
+                           .touch_policy = TOUCH_POLICY_NEVER}};
+  assert_int_equal(ck_generate_key(&key), 0);
+  assert_int_equal(ck_write_key("piv-pauk", &key), 0);
+
+  uint8_t data[6 + 66] = {0};
+  data[0] = 0x7C;
+  data[1] = 0x46;
+  data[2] = 0x82;
+  data[3] = 0x00;
+  data[4] = 0x81;
+  data[5] = 0x42;
+  for (uint8_t i = 0; i < 66; ++i)
+    data[6 + i] = i;
+
+  C = (CAPDU){.data = data, .cla = 0x00, .ins = PIV_INS_GENERAL_AUTHENTICATE, .p1 = 0x15, .p2 = 0x9A, .lc = sizeof(data)};
+  R.len = 0;
+  R.sw = 0;
+  piv_process_apdu(&C, &R);
+
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_true(R.len > 8);
+  assert_int_equal(R.data[0], 0x7C);
+  assert_int_equal(R.data[1], 0x82);
+  assert_int_equal(R.data[4], 0x82);
+  assert_int_equal(R.data[5], 0x82);
+  assert_int_equal(R.data[6], 0x00);
+  assert_true(R.data[7] >= 0x89);
+  assert_int_equal(R.data[8], 0x30);
+  assert_int_equal(R.data[9], 0x81);
+  assert_int_equal(R.data[10] + 3, R.data[7]);
+}
+
+static void test_secp521r1_custom_algorithm_id(void **state) {
+  (void)state;
+
+  const piv_algorithm_extension_config_t custom = {
+      .enabled = 1,
+      .ed25519 = 0xE0,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x16,
+      .x25519 = 0xE1,
+      .secp256k1 = 0x53,
+      .secp521r1 = 0x55,
+      .sm2 = 0x54,
+  };
+  assert_int_equal(piv_platform_algorithm_extension_config_write(&custom), 0);
+  assert_int_equal(piv_install(1), 0);
+  set_admin_status(1);
+
+  uint8_t r_buf[512];
+  uint8_t generate_with_policy[] = {0xAC, 0x06, 0x80, 0x01, 0x55, 0xAA, 0x01, 0x02, 0xAB, 0x01, 0x01};
+  CAPDU C = {.data = generate_with_policy,
+             .cla = 0x00,
+             .ins = PIV_INS_GENERATE_ASYMMETRIC_KEY_PAIR,
+             .p1 = 0x00,
+             .p2 = 0x9A,
+             .lc = sizeof(generate_with_policy)};
+  RAPDU R = {.data = r_buf};
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_int_equal(R.len, 140);
+
+  C = (CAPDU){.data = NULL, .cla = 0x00, .ins = PIV_INS_GET_METADATA, .p1 = 0x00, .p2 = 0x9A, .lc = 0};
+  R.len = 0;
+  R.sw = 0;
+  piv_process_apdu(&C, &R);
+  assert_int_equal(R.sw, SW_NO_ERROR);
+  assert_int_equal(R.data[2], 0x55);
+
+  const piv_algorithm_extension_config_t defaults = {
+      .enabled = 1,
+      .ed25519 = 0xE0,
+      .rsa3072 = 0x05,
+      .rsa4096 = 0x16,
+      .x25519 = 0xE1,
+      .secp256k1 = 0x53,
+      .secp521r1 = 0x15,
+      .sm2 = 0x54,
+  };
+  assert_int_equal(piv_platform_algorithm_extension_config_write(&defaults), 0);
+  assert_int_equal(piv_install(1), 0);
 }
 
 static void test_set_pin_retries(void **state) {
@@ -758,7 +969,11 @@ int main() {
       cmocka_unit_test(test_piv_delete_key_extension),
       cmocka_unit_test(test_piv_dynamic_retired_key_slots),
       cmocka_unit_test(test_piv_reset_preserves_platform_algorithm_extension),
+      cmocka_unit_test(test_piv_algorithm_extension_read_without_admin),
+      cmocka_unit_test(test_piv_algorithm_extension_read_after_write),
       cmocka_unit_test(test_ed25519_general_authenticate_long_message),
+      cmocka_unit_test(test_secp521r1_generate_and_authenticate),
+      cmocka_unit_test(test_secp521r1_custom_algorithm_id),
       cmocka_unit_test(test_set_pin_retries),
       cmocka_unit_test(test_set_pin_retries_failure_invalidates_auth),
       cmocka_unit_test(test_piv_cert_chained_read),


### PR DESCRIPTION
## Summary

This PR updates PIV algorithm-extension handling so hosts can inspect the currently effective extension mapping without first authenticating with the management key. The write path remains protected by admin status, but the read path now returns the runtime `alg_ext_cfg`, so a successful `00 EE 02 ...` update can be verified immediately with `00 EE 01 00 00`.

It also carries the current related PIV/OpenPGP work on this branch: SECP521R1 is added to the configurable PIV algorithm-extension mapping, PIV signatures are staged through the applet scratch buffer before wrapping large responses, the canokey-crypto submodule is advanced for SECP521R1 ANSI signature encoding, and a design overview document is added for the core resource/lifetime model.

## Root Cause

`PIV_INS_ALGORITHM_EXTENSION` previously checked `in_admin_status` before dispatching either read or write, so an unauthenticated status query returned `6982`. After loosening that gate for reads, the command still read back from platform config storage; on hardware this could show the persisted value rather than the value that had just become effective in `alg_ext_cfg`, making a successful write look unchanged during immediate verification.

## User Impact

Provisioning and diagnostics can now query the active PIV extension mapping directly. After writing a mapping such as SM2 `0x54`, a follow-up read reports the active runtime state immediately, while unauthorized writes continue to fail with `6982`.

## Validation

- `cmake --build build --target test_piv -j8`
- `./build/test/test_piv` (18/18 passed)

The test binary emits existing gcov `.gcda` merge warnings from stale coverage artifacts in the build tree; the command exits successfully and all tests pass.
