### PR TITLE
[codex] add admin core commit query

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,16 @@ add_custom_target(
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
 )
 
+add_custom_target(
+    generate_canokey_core_git_rev
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/canokey-core-git-rev.h
+    COMMAND ${CMAKE_COMMAND}
+        -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+        -DOUTPUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/canokey-core-git-rev.h
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_git_rev_header.cmake
+    COMMENT "Generating canokey-core-git-rev.h"
+)
+
 file(
     GLOB_RECURSE SRC
     src/*.c
@@ -199,7 +209,7 @@ target_include_directories(
         interfaces/USB/class/webusb
 )
 target_link_libraries(canokey-core canokey-crypto)
-add_dependencies(canokey-core generate_ctap_get_info_cbor)
+add_dependencies(canokey-core generate_ctap_get_info_cbor generate_canokey_core_git_rev)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,14 +103,18 @@ add_custom_target(
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ctap_get_info_cbor.inc
 )
 
-add_custom_target(
-    generate_canokey_core_git_rev
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/canokey-core-git-rev.h
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/canokey-core-git-rev.h
     COMMAND ${CMAKE_COMMAND}
         -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
         -DOUTPUT_FILE=${CMAKE_CURRENT_BINARY_DIR}/canokey-core-git-rev.h
         -P ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_git_rev_header.cmake
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/scripts/gen_git_rev_header.cmake
     COMMENT "Generating canokey-core-git-rev.h"
+)
+add_custom_target(
+    generate_canokey_core_git_rev
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/canokey-core-git-rev.h
 )
 
 file(

--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <admin.h>
+#include <canokey-core-git-rev.h>
 #include <crypto-util.h>
 #include <ctap.h>
 #include <device-config.h>
@@ -250,6 +251,15 @@ static int admin_read_sn(const CAPDU *capdu, RAPDU *rapdu) {
   return 0;
 }
 
+static int admin_read_core_commit(const CAPDU *capdu, RAPDU *rapdu) {
+  UNUSED(capdu);
+  const size_t len = sizeof(CANOKEY_CORE_GIT_REV) - 1;
+  memcpy(RDATA, CANOKEY_CORE_GIT_REV, len);
+  LL = len;
+  if (LL > LE) LL = LE;
+  return 0;
+}
+
 static int admin_config(const CAPDU *capdu, RAPDU *rapdu) {
   current_config = admin_get_current_config();
   switch (P1) {
@@ -458,11 +468,13 @@ int admin_process_apdu(const CAPDU *capdu, RAPDU *rapdu) {
     return 0;
 
   case ADMIN_INS_READ_VERSION:
-    if (P1 > 1 || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
+    if (P1 > ADMIN_P1_READ_CORE_COMMIT || P2 != 0x00) EXCEPT(SW_WRONG_P1P2);
     if (P1 == 0)
       ret = admin_vendor_version(capdu, rapdu);
     else if (P1 == 1)
       ret = admin_vendor_hw_variant(capdu, rapdu);
+    else if (P1 == ADMIN_P1_READ_CORE_COMMIT)
+      ret = admin_read_core_commit(capdu, rapdu);
     goto done;
 
   case ADMIN_INS_READ_SN:

--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -253,10 +253,11 @@ static int admin_read_sn(const CAPDU *capdu, RAPDU *rapdu) {
 
 static int admin_read_core_commit(const CAPDU *capdu, RAPDU *rapdu) {
   UNUSED(capdu);
-  const size_t len = sizeof(CANOKEY_CORE_GIT_REV) - 1;
+  size_t len = sizeof(CANOKEY_CORE_GIT_REV) - 1;
+  if (len > APDU_BUFFER_SIZE) len = APDU_BUFFER_SIZE;
+  if (len > LE) len = LE;
   memcpy(RDATA, CANOKEY_CORE_GIT_REV, len);
   LL = len;
-  if (LL > LE) LL = LE;
   return 0;
 }
 

--- a/include/admin.h
+++ b/include/admin.h
@@ -29,6 +29,14 @@
 #define ADMIN_INS_READ_PASS_CONFIG 0x43
 #define ADMIN_INS_WRITE_PASS_CONFIG 0x44
 
+/*
+ * ADMIN_INS_READ_VERSION:
+ *   P1 = 0x00: platform/vendor firmware version
+ *   P1 = 0x01: platform/vendor hardware variant
+ *   P1 = ADMIN_P1_READ_CORE_COMMIT: canokey-core git commit description
+ */
+#define ADMIN_P1_READ_CORE_COMMIT 0x02
+
 /**
  * ADMIN_INS_FLASH_USAGE:
  *   Read-only and intentionally available before admin PIN verification.

--- a/scripts/gen_git_rev_header.cmake
+++ b/scripts/gen_git_rev_header.cmake
@@ -1,0 +1,35 @@
+execute_process(
+    COMMAND git describe --always --tags --long --abbrev=8 --dirty
+    WORKING_DIRECTORY "${SOURCE_DIR}"
+    OUTPUT_VARIABLE GIT_REV
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+    RESULT_VARIABLE GIT_RESULT
+)
+
+if(NOT GIT_RESULT EQUAL 0 OR GIT_REV STREQUAL "")
+    set(GIT_REV "unknown")
+endif()
+
+string(REPLACE "\\" "\\\\" GIT_REV "${GIT_REV}")
+string(REPLACE "\"" "\\\"" GIT_REV "${GIT_REV}")
+
+set(HEADER_CONTENT
+"/* SPDX-License-Identifier: Apache-2.0 */
+#ifndef CANOKEY_CORE_GIT_REV_H_
+#define CANOKEY_CORE_GIT_REV_H_
+
+#define CANOKEY_CORE_GIT_REV \"${GIT_REV}\"
+
+#endif // CANOKEY_CORE_GIT_REV_H_
+")
+
+if(EXISTS "${OUTPUT_FILE}")
+    file(READ "${OUTPUT_FILE}" EXISTING_CONTENT)
+else()
+    set(EXISTING_CONTENT "")
+endif()
+
+if(NOT EXISTING_CONTENT STREQUAL HEADER_CONTENT)
+    file(WRITE "${OUTPUT_FILE}" "${HEADER_CONTENT}")
+endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ add_mocked_test(apdu
         ${CMAKE_CURRENT_SOURCE_DIR}/../virt-card/usb-dummy.c
         LINK_LIBRARIES canokey-core
 )
+add_dependencies(test_apdu generate_canokey_core_git_rev)
 
 add_mocked_test(piv
         SOURCES

--- a/test/test_apdu.c
+++ b/test/test_apdu.c
@@ -10,6 +10,7 @@
 #include <applet-scratch.h>
 #include <apdu.h>
 #include <bd/lfs_filebd.h>
+#include <canokey-core-git-rev.h>
 #include <ccid.h>
 #include <ctap.h>
 #include <device-config.h>
@@ -1797,6 +1798,29 @@ static void test_admin_platform_config_and_serial_apdus(void **state) {
   assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
 }
 
+static void test_admin_read_core_commit_apdu(void **state) {
+  (void)state;
+
+  uint8_t c_buf[64], r_buf[APDU_BUFFER_SIZE];
+  CAPDU capdu = {.data = c_buf};
+  RAPDU rapdu = {.data = r_buf};
+
+  init_apdu_buffer();
+  device_init();
+  assert_int_equal(applets_install(), 0);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_VERSION, ADMIN_P1_READ_CORE_COMMIT, 0x00, NULL, 0, sizeof(r_buf));
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_int_equal(rapdu.len, sizeof(CANOKEY_CORE_GIT_REV) - 1);
+  assert_memory_equal(rapdu.data, CANOKEY_CORE_GIT_REV, sizeof(CANOKEY_CORE_GIT_REV) - 1);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_VERSION, ADMIN_P1_READ_CORE_COMMIT, 0x01, NULL, 0, sizeof(r_buf));
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  admin_send(&capdu, &rapdu, ADMIN_INS_READ_VERSION, ADMIN_P1_READ_CORE_COMMIT + 1, 0x00, NULL, 0, sizeof(r_buf));
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+}
+
 static void test_admin_flash_usage_apdus(void **state) {
   (void)state;
 
@@ -1973,6 +1997,7 @@ int main() {
       cmocka_unit_test(test_response_source_clear_calls_close),
       cmocka_unit_test(test_fido_magic_reboot_after_reset_without_select),
       cmocka_unit_test(test_admin_platform_config_and_serial_apdus),
+      cmocka_unit_test(test_admin_read_core_commit_apdu),
       cmocka_unit_test(test_admin_flash_usage_apdus),
       cmocka_unit_test(test_admin_kbd_keymap_apdus),
   };

--- a/test/test_apdu.c
+++ b/test/test_apdu.c
@@ -1811,8 +1811,10 @@ static void test_admin_read_core_commit_apdu(void **state) {
 
   admin_send(&capdu, &rapdu, ADMIN_INS_READ_VERSION, ADMIN_P1_READ_CORE_COMMIT, 0x00, NULL, 0, sizeof(r_buf));
   assert_int_equal(rapdu.sw, SW_NO_ERROR);
-  assert_int_equal(rapdu.len, sizeof(CANOKEY_CORE_GIT_REV) - 1);
-  assert_memory_equal(rapdu.data, CANOKEY_CORE_GIT_REV, sizeof(CANOKEY_CORE_GIT_REV) - 1);
+  size_t expected_len = sizeof(CANOKEY_CORE_GIT_REV) - 1;
+  if (expected_len > APDU_BUFFER_SIZE) expected_len = APDU_BUFFER_SIZE;
+  assert_int_equal(rapdu.len, expected_len);
+  assert_memory_equal(rapdu.data, CANOKEY_CORE_GIT_REV, expected_len);
 
   admin_send(&capdu, &rapdu, ADMIN_INS_READ_VERSION, ADMIN_P1_READ_CORE_COMMIT, 0x01, NULL, 0, sizeof(r_buf));
   assert_int_equal(rapdu.sw, SW_WRONG_P1P2);


### PR DESCRIPTION
## Summary
- add an admin `READ_VERSION` subcommand (`INS=0x31`, `P1=0x02`) that returns the canokey-core git commit description
- generate `canokey-core-git-rev.h` at build time from `git describe --always --tags --long --abbrev=8 --dirty`
- cover the new APDU path and invalid P1/P2 handling in `test_apdu`

## Impact
Host tooling can query the core library revision through the existing admin version command family without adding a new INS. The generated header lives in the build directory and falls back to `unknown` when git metadata is unavailable.

## Validation
- `cmake -S . -B build-test -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-test --target test_apdu -j4`
- `./build-test/test/test_apdu` (39 tests passed)

Note: the existing `test_apdu_output_chaining_aliased_buffer` path still emits a UBSan runtime warning at `src/apdu.c:341`; it predates this change and the suite exits successfully.
