### PR TITLE
[codex] Add runtime feature switches

### DIFF
--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -156,7 +156,7 @@ static const admin_device_config_t default_cfg = {
 };
 
 static admin_device_config_t current_config;
-static admin_device_config_t admin_get_current_config(void);
+static uint8_t current_config_valid;
 
 __attribute__((weak)) int admin_vendor_specific(const CAPDU *capdu, RAPDU *rapdu) {
   UNUSED(capdu);
@@ -189,8 +189,11 @@ __attribute__((weak)) int admin_vendor_nfc_enable(const CAPDU *capdu, RAPDU *rap
   return 0;
 }
 
-// Query the platform hook on every read so a platform-backed config is not
-// shadowed by core RAM after a vendor/admin APDU updates flash directly.
+static admin_device_config_t admin_get_current_config(void) {
+  if (current_config_valid) return current_config;
+  return default_cfg;
+}
+
 uint8_t device_config_is_led_normally_on(void) { return admin_get_current_config().led_normally_on; }
 
 uint8_t device_config_is_ndef_enabled(void) { return admin_get_current_config().ndef_en; }
@@ -209,22 +212,15 @@ uint8_t device_config_is_piv_nfc_enabled(void) { return admin_get_current_config
 
 uint8_t device_config_is_webauthn_enabled(void) { return admin_get_current_config().webauthn_en; }
 
-static admin_device_config_t admin_get_current_config(void) {
-  admin_device_config_t cfg = default_cfg;
-  if (admin_platform_device_config_read(&cfg) == 0) return cfg;
-  return default_cfg;
-}
-
 void admin_poweroff(void) { pin.is_validated = 0; }
 
 int admin_install(const uint8_t reset) {
   admin_poweroff();
-  // Device config is platform-backed. Core keeps no LittleFS fallback, which
-  // avoids two independent sources of truth for LED/NDEF/WebUSB flags.
   if (reset || admin_platform_device_config_read(&current_config) < 0) {
     current_config = default_cfg;
     if (admin_platform_device_config_write(&current_config) < 0) return -1;
   }
+  current_config_valid = 1;
   if (reset || get_file_size(pin.path) < 0) {
     if (pin_create(&pin, "123456", 6, PIN_RETRY_COUNTER) < 0) return -1;
   }
@@ -284,31 +280,35 @@ static int admin_read_core_commit(const CAPDU *capdu, RAPDU *rapdu) {
 }
 
 static int admin_config(const CAPDU *capdu, RAPDU *rapdu) {
-  current_config = admin_get_current_config();
+  admin_device_config_t next_config = admin_get_current_config();
   switch (P1) {
   case ADMIN_P1_CFG_LED_ON:
-    current_config.led_normally_on = P2 & 1;
+    next_config.led_normally_on = P2 & 1;
     break;
   case ADMIN_P1_CFG_NDEF:
-    current_config.ndef_en = P2 & 1;
+    next_config.ndef_en = P2 & 1;
     break;
   case ADMIN_P1_CFG_WEBUSB_LANDING:
-    current_config.webusb_landing_en = P2 & 1;
+    next_config.webusb_landing_en = P2 & 1;
     break;
   case ADMIN_P1_CFG_FEATURE:
     if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
     if ((P2 & ~ADMIN_FEATURE_MASK) != 0) EXCEPT(SW_WRONG_P1P2);
-    current_config.pass_en = (P2 & ADMIN_FEATURE_PASS) != 0;
-    current_config.openpgp_ccid_en = (P2 & ADMIN_FEATURE_OPENPGP_CCID) != 0;
-    current_config.openpgp_nfc_en = (P2 & ADMIN_FEATURE_OPENPGP_NFC) != 0;
-    current_config.piv_ccid_en = (P2 & ADMIN_FEATURE_PIV_CCID) != 0;
-    current_config.piv_nfc_en = (P2 & ADMIN_FEATURE_PIV_NFC) != 0;
-    current_config.webauthn_en = (P2 & ADMIN_FEATURE_WEBAUTHN) != 0;
+    next_config.pass_en = (P2 & ADMIN_FEATURE_PASS) != 0;
+    next_config.openpgp_ccid_en = (P2 & ADMIN_FEATURE_OPENPGP_CCID) != 0;
+    next_config.openpgp_nfc_en = (P2 & ADMIN_FEATURE_OPENPGP_NFC) != 0;
+    next_config.piv_ccid_en = (P2 & ADMIN_FEATURE_PIV_CCID) != 0;
+    next_config.piv_nfc_en = (P2 & ADMIN_FEATURE_PIV_NFC) != 0;
+    next_config.webauthn_en = (P2 & ADMIN_FEATURE_WEBAUTHN) != 0;
     break;
   default:
     EXCEPT(SW_WRONG_P1P2);
   }
-  const int ret = admin_platform_device_config_write(&current_config);
+  const int ret = admin_platform_device_config_write(&next_config);
+  if (ret == 0) {
+    current_config = next_config;
+    current_config_valid = 1;
+  }
   stop_blinking();
   return ret;
 }

--- a/applets/admin/admin.c
+++ b/applets/admin/admin.c
@@ -143,7 +143,17 @@ static const admin_applet_usage_def_t applet_usage_defs[] = {
     {ADMIN_APPLET_USAGE_ID_PASS, pass_usage_sources, sizeof(pass_usage_sources) / sizeof(pass_usage_sources[0])},
 };
 
-static const admin_device_config_t default_cfg = {.led_normally_on = 1, .ndef_en = 1, .webusb_landing_en = 1};
+static const admin_device_config_t default_cfg = {
+    .led_normally_on = 1,
+    .ndef_en = 1,
+    .webusb_landing_en = 1,
+    .pass_en = 1,
+    .openpgp_ccid_en = 1,
+    .openpgp_nfc_en = 1,
+    .piv_ccid_en = 1,
+    .piv_nfc_en = 1,
+    .webauthn_en = 1,
+};
 
 static admin_device_config_t current_config;
 static admin_device_config_t admin_get_current_config(void);
@@ -186,6 +196,18 @@ uint8_t device_config_is_led_normally_on(void) { return admin_get_current_config
 uint8_t device_config_is_ndef_enabled(void) { return admin_get_current_config().ndef_en; }
 
 uint8_t device_config_is_webusb_landing_enabled(void) { return admin_get_current_config().webusb_landing_en; }
+
+uint8_t device_config_is_pass_enabled(void) { return admin_get_current_config().pass_en; }
+
+uint8_t device_config_is_openpgp_ccid_enabled(void) { return admin_get_current_config().openpgp_ccid_en; }
+
+uint8_t device_config_is_openpgp_nfc_enabled(void) { return admin_get_current_config().openpgp_nfc_en; }
+
+uint8_t device_config_is_piv_ccid_enabled(void) { return admin_get_current_config().piv_ccid_en; }
+
+uint8_t device_config_is_piv_nfc_enabled(void) { return admin_get_current_config().piv_nfc_en; }
+
+uint8_t device_config_is_webauthn_enabled(void) { return admin_get_current_config().webauthn_en; }
 
 static admin_device_config_t admin_get_current_config(void) {
   admin_device_config_t cfg = default_cfg;
@@ -273,6 +295,16 @@ static int admin_config(const CAPDU *capdu, RAPDU *rapdu) {
   case ADMIN_P1_CFG_WEBUSB_LANDING:
     current_config.webusb_landing_en = P2 & 1;
     break;
+  case ADMIN_P1_CFG_FEATURE:
+    if (LC != 0) EXCEPT(SW_WRONG_LENGTH);
+    if ((P2 & ~ADMIN_FEATURE_MASK) != 0) EXCEPT(SW_WRONG_P1P2);
+    current_config.pass_en = (P2 & ADMIN_FEATURE_PASS) != 0;
+    current_config.openpgp_ccid_en = (P2 & ADMIN_FEATURE_OPENPGP_CCID) != 0;
+    current_config.openpgp_nfc_en = (P2 & ADMIN_FEATURE_OPENPGP_NFC) != 0;
+    current_config.piv_ccid_en = (P2 & ADMIN_FEATURE_PIV_CCID) != 0;
+    current_config.piv_nfc_en = (P2 & ADMIN_FEATURE_PIV_NFC) != 0;
+    current_config.webauthn_en = (P2 & ADMIN_FEATURE_WEBAUTHN) != 0;
+    break;
   default:
     EXCEPT(SW_WRONG_P1P2);
   }
@@ -296,7 +328,9 @@ static int admin_read_config(const CAPDU *capdu, RAPDU *rapdu) {
 #endif
   RDATA[3] = cfg.ndef_en;
   RDATA[4] = cfg.webusb_landing_en;
-  RDATA[5] = 0; // reserved
+  RDATA[5] = (cfg.pass_en ? ADMIN_FEATURE_PASS : 0) | (cfg.openpgp_ccid_en ? ADMIN_FEATURE_OPENPGP_CCID : 0) |
+             (cfg.openpgp_nfc_en ? ADMIN_FEATURE_OPENPGP_NFC : 0) | (cfg.piv_ccid_en ? ADMIN_FEATURE_PIV_CCID : 0) |
+             (cfg.piv_nfc_en ? ADMIN_FEATURE_PIV_NFC : 0) | (cfg.webauthn_en ? ADMIN_FEATURE_WEBAUTHN : 0);
   LL = 6;
 
   return 0;

--- a/include/admin.h
+++ b/include/admin.h
@@ -108,11 +108,35 @@
 #define ADMIN_P1_CFG_LED_ON 0x01
 #define ADMIN_P1_CFG_NDEF 0x04
 #define ADMIN_P1_CFG_WEBUSB_LANDING 0x05
+#define ADMIN_P1_CFG_FEATURE 0x06
+
+#define ADMIN_FEATURE_PASS_BIT 0x00
+#define ADMIN_FEATURE_OPENPGP_CCID_BIT 0x01
+#define ADMIN_FEATURE_OPENPGP_NFC_BIT 0x02
+#define ADMIN_FEATURE_PIV_CCID_BIT 0x03
+#define ADMIN_FEATURE_PIV_NFC_BIT 0x04
+#define ADMIN_FEATURE_WEBAUTHN_BIT 0x05
+#define ADMIN_FEATURE_COUNT 0x06
+#define ADMIN_FEATURE_PASS (1u << ADMIN_FEATURE_PASS_BIT)
+#define ADMIN_FEATURE_OPENPGP_CCID (1u << ADMIN_FEATURE_OPENPGP_CCID_BIT)
+#define ADMIN_FEATURE_OPENPGP_NFC (1u << ADMIN_FEATURE_OPENPGP_NFC_BIT)
+#define ADMIN_FEATURE_PIV_CCID (1u << ADMIN_FEATURE_PIV_CCID_BIT)
+#define ADMIN_FEATURE_PIV_NFC (1u << ADMIN_FEATURE_PIV_NFC_BIT)
+#define ADMIN_FEATURE_WEBAUTHN (1u << ADMIN_FEATURE_WEBAUTHN_BIT)
+#define ADMIN_FEATURE_MASK                                                                                           \
+  (ADMIN_FEATURE_PASS | ADMIN_FEATURE_OPENPGP_CCID | ADMIN_FEATURE_OPENPGP_NFC | ADMIN_FEATURE_PIV_CCID |            \
+   ADMIN_FEATURE_PIV_NFC | ADMIN_FEATURE_WEBAUTHN)
 
 typedef struct {
   uint32_t led_normally_on : 1;
   uint32_t ndef_en : 1;
   uint32_t webusb_landing_en : 1;
+  uint32_t pass_en : 1;
+  uint32_t openpgp_ccid_en : 1;
+  uint32_t openpgp_nfc_en : 1;
+  uint32_t piv_ccid_en : 1;
+  uint32_t piv_nfc_en : 1;
+  uint32_t webauthn_en : 1;
 } __packed admin_device_config_t;
 
 void admin_poweroff(void);

--- a/include/apdu.h
+++ b/include/apdu.h
@@ -116,6 +116,14 @@ int apdu_session_can_preempt(void);
 void apdu_fido_chain_reset(void);
 int acquire_apdu_interface(uint8_t session_owner, uint8_t buffer_owner);
 void release_apdu_interface(uint8_t session_owner, uint8_t buffer_owner);
+typedef enum {
+  APDU_TRANSPORT_CCID,
+  APDU_TRANSPORT_WEBUSB,
+  APDU_TRANSPORT_NFC,
+  APDU_TRANSPORT_HID,
+} apdu_transport_t;
+
+void process_apdu_from(CAPDU *capdu, RAPDU *rapdu, apdu_transport_t transport);
 void process_apdu(CAPDU *capdu, RAPDU *rapdu);
 
 #endif // CANOKEY_CORE__APDU_H

--- a/include/device-config.h
+++ b/include/device-config.h
@@ -11,6 +11,12 @@
 uint8_t device_config_is_led_normally_on(void);
 uint8_t device_config_is_ndef_enabled(void);
 uint8_t device_config_is_webusb_landing_enabled(void);
+uint8_t device_config_is_pass_enabled(void);
+uint8_t device_config_is_openpgp_ccid_enabled(void);
+uint8_t device_config_is_openpgp_nfc_enabled(void);
+uint8_t device_config_is_piv_ccid_enabled(void);
+uint8_t device_config_is_piv_nfc_enabled(void);
+uint8_t device_config_is_webauthn_enabled(void);
 uint8_t device_config_is_initialized(void);
 int device_config_mark_initialized(void);
 uint8_t device_config_is_nfc_enabled(void);

--- a/interfaces/NFC/nfc.c
+++ b/interfaces/NFC/nfc.c
@@ -47,7 +47,7 @@ static int load_next_aggregated_chunk(void) {
   RAPDU rapdu = {.data = shared_io_buffer};
 
   device_set_timeout(send_wtx, WTX_PERIOD);
-  process_apdu(&capdu, &rapdu);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_NFC);
   device_set_timeout(NULL, 0);
 
   apdu_buffer_sent = 0;
@@ -188,7 +188,7 @@ void nfc_loop(void) {
         SW = SW_WRONG_LENGTH;
       } else {
         device_set_timeout(send_wtx, WTX_PERIOD);
-        process_apdu(capdu, rapdu);
+        process_apdu_from(capdu, rapdu, APDU_TRANSPORT_NFC);
         device_set_timeout(NULL, 0);
       }
 

--- a/interfaces/USB/class/ccid/ccid.c
+++ b/interfaces/USB/class/ccid/ccid.c
@@ -214,7 +214,7 @@ uint8_t PC_to_RDR_XfrBlock(void) {
               LC > 0 ? DATA[0] : 0, LC > 1 ? DATA[1] : 0, LC > 2 ? DATA[2] : 0, LC > 3 ? DATA[3] : 0);
     }
     device_set_timeout(CCID_TimeExtensionLoop, TIME_EXTENSION_PERIOD);
-    process_apdu(capdu, rapdu);
+    process_apdu_from(capdu, rapdu, APDU_TRANSPORT_CCID);
     device_set_timeout(NULL, 0);
   }
 

--- a/interfaces/USB/class/ctaphid/ctaphid.c
+++ b/interfaces/USB/class/ctaphid/ctaphid.c
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <ctap.h>
 #include <ctaphid.h>
+#include <device-config.h>
 #include <device.h>
 #include <rand.h>
 #include <usb_device.h>
@@ -121,6 +122,10 @@ static uint8_t CTAPHID_DispatchComplete(uint8_t wait_for_user) {
   channel.expire = UINT32_MAX;
   switch (channel.cmd) {
   case CTAPHID_MSG:
+    if (!device_config_is_webauthn_enabled()) {
+      CTAPHID_SendErrorResponse(channel.cid, ERR_INVALID_CMD);
+      break;
+    }
     if (wait_for_user)
       CTAPHID_SendErrorResponse(channel.cid, ERR_CHANNEL_BUSY);
     else if (channel.bcnt_total < 4)
@@ -129,6 +134,10 @@ static uint8_t CTAPHID_DispatchComplete(uint8_t wait_for_user) {
       CTAPHID_Execute_Msg();
     break;
   case CTAPHID_CBOR:
+    if (!device_config_is_webauthn_enabled()) {
+      CTAPHID_SendErrorResponse(channel.cid, ERR_INVALID_CMD);
+      break;
+    }
     if (wait_for_user)
       CTAPHID_SendErrorResponse(channel.cid, ERR_CHANNEL_BUSY);
     else if (channel.bcnt_total == 0)

--- a/interfaces/USB/class/webusb/webusb.c
+++ b/interfaces/USB/class/webusb/webusb.c
@@ -111,7 +111,7 @@ void WebUSB_Loop(void) {
     SW = SW_CONDITIONS_NOT_SATISFIED;
   } else {
     device_applet_session_touch(DEVICE_APPLET_SESSION_WEBUSB);
-    process_apdu(capdu, rapdu);
+    process_apdu_from(capdu, rapdu, APDU_TRANSPORT_WEBUSB);
   }
 
   apdu_buffer_size = LL + 2;

--- a/interfaces/USB/device/usbd_canokey.c
+++ b/interfaces/USB/device/usbd_canokey.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <usbd_canokey.h>
+#include <device-config.h>
 #if ENABLE_IFACE_CCID
 #include <usbd_ccid.h>
 #endif
@@ -33,7 +34,7 @@ static uint8_t USBD_CANOKEY_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx) {
   USBD_CTAPHID_Init(pdev);
 #endif
 #if ENABLE_IFACE_KBDHID
-  USBD_KBDHID_Init(pdev);
+  if (device_config_is_pass_enabled()) USBD_KBDHID_Init(pdev);
 #endif
 #if ENABLE_IFACE_CCID
   USBD_CCID_Init(pdev);
@@ -84,8 +85,9 @@ static uint8_t USBD_CANOKEY_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef
     return USBD_CTAPHID_Setup(pdev, req);
 #endif
 #if ENABLE_IFACE_KBDHID
-  if (((recipient == USB_REQ_RECIPIENT_INTERFACE || is_hid_get_descriptor) && req->wIndex == USBD_CANOKEY_KBDHID_IF) ||
-      (recipient == USB_REQ_RECIPIENT_ENDPOINT && (req->wIndex == EP_IN(kbd_hid) || req->wIndex == EP_OUT(kbd_hid))))
+  if (device_config_is_pass_enabled() &&
+      (((recipient == USB_REQ_RECIPIENT_INTERFACE || is_hid_get_descriptor) && req->wIndex == USBD_CANOKEY_KBDHID_IF) ||
+       (recipient == USB_REQ_RECIPIENT_ENDPOINT && (req->wIndex == EP_IN(kbd_hid) || req->wIndex == EP_OUT(kbd_hid)))))
     return USBD_KBDHID_Setup(pdev, req);
 #endif
 #if ENABLE_IFACE_WEBUSB
@@ -106,7 +108,7 @@ static uint8_t USBD_CANOKEY_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum) {
   if (epnum == (0x7F & EP_IN(ctap_hid))) return USBD_CTAPHID_DataIn();
 #endif
 #if ENABLE_IFACE_KBDHID
-  if (epnum == (0x7F & EP_IN(kbd_hid))) return USBD_KBDHID_DataIn();
+  if (device_config_is_pass_enabled() && epnum == (0x7F & EP_IN(kbd_hid))) return USBD_KBDHID_DataIn();
 #endif
 #if ENABLE_IFACE_CCID
   if (epnum == (0x7F & EP_IN(ccid))) return USBD_CCID_DataIn(pdev);
@@ -123,7 +125,7 @@ static uint8_t USBD_CANOKEY_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
   if (epnum == EP_OUT(ctap_hid)) return USBD_CTAPHID_DataOut(pdev);
 #endif
 #if ENABLE_IFACE_KBDHID
-  if (epnum == EP_OUT(kbd_hid)) return USBD_KBDHID_DataOut(pdev);
+  if (device_config_is_pass_enabled() && epnum == EP_OUT(kbd_hid)) return USBD_KBDHID_DataOut(pdev);
 #endif
 #if ENABLE_IFACE_CCID
   if (epnum == EP_OUT(ccid)) return USBD_CCID_DataOut(pdev);

--- a/interfaces/USB/device/usbd_desc.c
+++ b/interfaces/USB/device/usbd_desc.c
@@ -406,7 +406,7 @@ void USBD_DescriptorInit(void) {
   nIface++;
 #endif
 
-  if (IS_ENABLED_IFACE(USBD_CANOKEY_KBDHID_IF)) {
+  if (IS_ENABLED_IFACE(USBD_CANOKEY_KBDHID_IF) && device_config_is_pass_enabled()) {
 #if ENABLE_IFACE_KBDHID
     nIface++;
     memcpy(desc, USBD_FS_IfDesc_KBDHID, sizeof(USBD_FS_IfDesc_KBDHID));

--- a/src/apdu.c
+++ b/src/apdu.c
@@ -71,6 +71,8 @@ static uint16_t response_tail_len;
 static uint8_t apdu_fallback_buffer[APDU_COMMAND_BUFFER_SIZE];
 #endif
 
+static void fido_capdu_reset(void);
+
 typedef struct {
   uint8_t active;
   uint32_t total_len;
@@ -103,6 +105,28 @@ static uint8_t is_fido_apdu(const CAPDU *capdu) {
   default:
     return 0;
   }
+}
+
+static uint8_t applet_enabled_on_transport(enum APPLET applet, apdu_transport_t transport) {
+  switch (applet) {
+  case APPLET_OPENPGP:
+    return transport == APDU_TRANSPORT_NFC ? device_config_is_openpgp_nfc_enabled() : device_config_is_openpgp_ccid_enabled();
+  case APPLET_PIV:
+    return transport == APDU_TRANSPORT_NFC ? device_config_is_piv_nfc_enabled() : device_config_is_piv_ccid_enabled();
+  case APPLET_FIDO:
+    return device_config_is_webauthn_enabled();
+  default:
+    return 1;
+  }
+}
+
+static void disabled_applet_response(RAPDU *rapdu) {
+  current_applet = APPLET_NULL;
+  apdu_response_source_clear();
+  memset(&rapdu_chaining, 0, sizeof(rapdu_chaining));
+  fido_capdu_reset();
+  LL = 0;
+  SW = SW_FILE_NOT_FOUND;
 }
 
 static APDU_RESPONSE_SOURCE response_source;
@@ -422,9 +446,9 @@ void release_apdu_interface(uint8_t session_owner, uint8_t buffer_owner) {
   device_applet_session_release((device_applet_session_owner_t)session_owner);
 }
 
-void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
+void process_apdu_from(CAPDU *capdu, RAPDU *rapdu, apdu_transport_t transport) {
 #if ENABLE_IFACE_KBDHID
-  if (CLA == 0xFF && INS == 0xEE && P1 == 0xFF && P2 == 0xEE) {
+  if (device_config_is_pass_enabled() && CLA == 0xFF && INS == 0xEE && P1 == 0xFF && P2 == 0xEE) {
     // A special APDU to trigger Eject
     KBDHID_Eject();
     LL = 0;
@@ -434,10 +458,18 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
 #endif
   if (!(CLA == 0x00 && INS == 0xA4 && P1 == 0x04 && P2 == 0x00)) {
     if (current_applet == APPLET_PIV) {
+      if (!applet_enabled_on_transport(APPLET_PIV, transport)) {
+        disabled_applet_response(rapdu);
+        return;
+      }
       piv_process_apdu_message(&rapdu_chaining, capdu, rapdu);
       return;
     }
     if (current_applet == APPLET_OPENPGP) {
+      if (!applet_enabled_on_transport(APPLET_OPENPGP, transport)) {
+        disabled_applet_response(rapdu);
+        return;
+      }
       openpgp_process_apdu_message(&rapdu_chaining, capdu, rapdu);
       return;
     }
@@ -466,6 +498,11 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
     uint8_t i, end = APPLET_ENUM_END;
     for (i = APPLET_NULL + 1; i != end; ++i) {
       if (LC >= AID_Size[i] && memcmp(DATA, AID[i], AID_Size[i]) == 0) {
+        if (!applet_enabled_on_transport((enum APPLET)i, transport)) {
+          disabled_applet_response(rapdu);
+          DBG_MSG("applet disabled: %d\n", i);
+          return;
+        }
 #if ENABLE_APPLET_NDEF
         if (i == APPLET_NDEF && !device_config_is_ndef_enabled()) {
           LL = 0;
@@ -497,6 +534,10 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
     // Some PC/SC stacks reconnect or reset the card between CTAP INIT and the
     // next CBOR/U2F exchange. Accepting unmistakably FIDO APDUs here keeps the
     // FIDO CCID path usable across those implicit resets.
+    if (!applet_enabled_on_transport(APPLET_FIDO, transport)) {
+      disabled_applet_response(rapdu);
+      return;
+    }
     current_applet = APPLET_FIDO;
     DBG_MSG("implicit applet switched to: %d\n", current_applet);
   }
@@ -512,6 +553,10 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
     apdu_output(&rapdu_chaining, rapdu);
     break;
   case APPLET_FIDO:
+    if (!applet_enabled_on_transport(APPLET_FIDO, transport)) {
+      disabled_applet_response(rapdu);
+      break;
+    }
 #ifdef TEST
     if (CLA == 0x00 && INS == 0xEE && LC == 0x04 && memcmp(DATA, "\x12\x56\xAB\xF0", 4) == 0) {
       printf("MAGIC REBOOT command received!\r\n");
@@ -575,6 +620,8 @@ void process_apdu(CAPDU *capdu, RAPDU *rapdu) {
     SW = SW_FILE_NOT_FOUND;
   }
 }
+
+void process_apdu(CAPDU *capdu, RAPDU *rapdu) { process_apdu_from(capdu, rapdu, APDU_TRANSPORT_CCID); }
 
 int acquire_apdu_buffer(uint8_t owner) {
   device_atomic_compare_and_swap(&buffer_owner, BUFFER_OWNER_NONE, owner);

--- a/src/device.c
+++ b/src/device.c
@@ -70,7 +70,7 @@ void device_loop(void) {
   WebUSB_Loop();
 #endif
 #if ENABLE_IFACE_KBDHID
-  KBDHID_Loop();
+  if (device_config_is_pass_enabled()) KBDHID_Loop();
 #endif
 }
 

--- a/src/platform-config.c
+++ b/src/platform-config.c
@@ -29,6 +29,15 @@
 #define CONFIG_FLAG_WEBUSB_LANDING_ENABLED (1u << 4)
 #define CONFIG_FLAG_SN_VALID (1u << 5)
 #define CONFIG_FLAG_KBD_KEYMAP_VALID (1u << 6)
+#define CONFIG_FLAG_PASS_ENABLED (1u << 7)
+#define CONFIG_FLAG_OPENPGP_CCID_ENABLED (1u << 8)
+#define CONFIG_FLAG_OPENPGP_NFC_ENABLED (1u << 9)
+#define CONFIG_FLAG_PIV_CCID_ENABLED (1u << 10)
+#define CONFIG_FLAG_PIV_NFC_ENABLED (1u << 11)
+#define CONFIG_FLAG_WEBAUTHN_ENABLED (1u << 12)
+#define CONFIG_FLAGS_FEATURES                                                                                         \
+  (CONFIG_FLAG_PASS_ENABLED | CONFIG_FLAG_OPENPGP_CCID_ENABLED | CONFIG_FLAG_OPENPGP_NFC_ENABLED |                    \
+   CONFIG_FLAG_PIV_CCID_ENABLED | CONFIG_FLAG_PIV_NFC_ENABLED | CONFIG_FLAG_WEBAUTHN_ENABLED)
 
 // The first word is platform-owned loader handoff state and is excluded from
 // the core config CRC. The rest of the page is owned by this module.
@@ -106,7 +115,7 @@ static void config_set_defaults(config_page_t *page, uint32_t platform_word) {
   page->header_len = CONFIG_HEADER_LEN;
   page->page_len = PLATFORM_CONFIG_PAGE_SIZE;
   page->flags = CONFIG_FLAG_NFC_ENABLED | CONFIG_FLAG_LED_NORMALLY_ON | CONFIG_FLAG_NDEF_ENABLED |
-                CONFIG_FLAG_WEBUSB_LANDING_ENABLED;
+                CONFIG_FLAG_WEBUSB_LANDING_ENABLED | CONFIG_FLAGS_FEATURES;
   memset(page->serial, 0, sizeof(page->serial));
   page->kbd_layout_id = 0;
   page->kbd_entry_size = CONFIG_KBD_ENTRY_SIZE;
@@ -196,6 +205,30 @@ static int set_admin_cfg_update(config_page_t *page, void *ctx) {
     page->flags |= CONFIG_FLAG_WEBUSB_LANDING_ENABLED;
   else
     page->flags &= ~CONFIG_FLAG_WEBUSB_LANDING_ENABLED;
+  if (cfg->pass_en)
+    page->flags |= CONFIG_FLAG_PASS_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_PASS_ENABLED;
+  if (cfg->openpgp_ccid_en)
+    page->flags |= CONFIG_FLAG_OPENPGP_CCID_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_OPENPGP_CCID_ENABLED;
+  if (cfg->openpgp_nfc_en)
+    page->flags |= CONFIG_FLAG_OPENPGP_NFC_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_OPENPGP_NFC_ENABLED;
+  if (cfg->piv_ccid_en)
+    page->flags |= CONFIG_FLAG_PIV_CCID_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_PIV_CCID_ENABLED;
+  if (cfg->piv_nfc_en)
+    page->flags |= CONFIG_FLAG_PIV_NFC_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_PIV_NFC_ENABLED;
+  if (cfg->webauthn_en)
+    page->flags |= CONFIG_FLAG_WEBAUTHN_ENABLED;
+  else
+    page->flags &= ~CONFIG_FLAG_WEBAUTHN_ENABLED;
   return 0;
 }
 
@@ -288,6 +321,12 @@ int admin_platform_device_config_read(admin_device_config_t *cfg) {
   cfg->led_normally_on = (page.flags & CONFIG_FLAG_LED_NORMALLY_ON) != 0;
   cfg->ndef_en = (page.flags & CONFIG_FLAG_NDEF_ENABLED) != 0;
   cfg->webusb_landing_en = (page.flags & CONFIG_FLAG_WEBUSB_LANDING_ENABLED) != 0;
+  cfg->pass_en = (page.flags & CONFIG_FLAG_PASS_ENABLED) != 0;
+  cfg->openpgp_ccid_en = (page.flags & CONFIG_FLAG_OPENPGP_CCID_ENABLED) != 0;
+  cfg->openpgp_nfc_en = (page.flags & CONFIG_FLAG_OPENPGP_NFC_ENABLED) != 0;
+  cfg->piv_ccid_en = (page.flags & CONFIG_FLAG_PIV_CCID_ENABLED) != 0;
+  cfg->piv_nfc_en = (page.flags & CONFIG_FLAG_PIV_NFC_ENABLED) != 0;
+  cfg->webauthn_en = (page.flags & CONFIG_FLAG_WEBAUTHN_ENABLED) != 0;
   return 0;
 }
 

--- a/test-via-pcsc/admin_test.go
+++ b/test-via-pcsc/admin_test.go
@@ -197,7 +197,7 @@ func commandTests(verified bool, app *AdminApplet) func(C) {
 			}
 		})
 		Convey("Configuration", func(ctx C) {
-			shadowCfg := []byte{0x01, 0x00, 0x00, 0x01, 0x01, 0x00}
+			shadowCfg := []byte{0x01, 0x00, 0x00, 0x01, 0x01, 0x3F}
 			P1toIdx := map[int]int{
 				1: 0, // ADMIN_P1_CFG_LED_ON
 				2: 2, // NDEF read-only CC flag

--- a/test/test_apdu.c
+++ b/test/test_apdu.c
@@ -1715,6 +1715,12 @@ static void admin_verify_default_pin(CAPDU *capdu, RAPDU *rapdu) {
   assert_int_equal(rapdu->len, 0);
 }
 
+static void admin_set_feature_mask(CAPDU *capdu, RAPDU *rapdu, uint8_t mask) {
+  admin_send(capdu, rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_FEATURE, mask, NULL, 0, 0);
+  assert_int_equal(rapdu->sw, SW_NO_ERROR);
+  assert_int_equal(rapdu->len, 0);
+}
+
 static uint32_t admin_usage_record_bytes(const uint8_t *data, uint8_t id, uint8_t *flags) {
   for (size_t off = 0; off < ADMIN_APPLET_USAGE_RESPONSE_LENGTH; off += ADMIN_APPLET_USAGE_RECORD_LENGTH) {
     if (data[off] != id) continue;
@@ -1755,6 +1761,7 @@ static void test_admin_platform_config_and_serial_apdus(void **state) {
   assert_int_equal(rapdu.data[0], 1);
   assert_int_equal(rapdu.data[3], 1);
   assert_int_equal(rapdu.data[4], 1);
+  assert_int_equal(rapdu.data[5], ADMIN_FEATURE_MASK);
 
   admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_LED_ON, 0x00, NULL, 0, 0);
   assert_int_equal(rapdu.sw, SW_NO_ERROR);
@@ -1768,6 +1775,21 @@ static void test_admin_platform_config_and_serial_apdus(void **state) {
   assert_int_equal(rapdu.sw, SW_NO_ERROR);
   assert_int_equal(device_config_is_webusb_landing_enabled(), 0);
 
+  admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_FEATURE, ADMIN_FEATURE_MASK | 0x80, NULL, 0, 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
+
+  uint8_t feature_value = 0;
+  admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, ADMIN_P1_CFG_FEATURE, ADMIN_FEATURE_MASK, &feature_value, 1, 0);
+  assert_int_equal(rapdu.sw, SW_WRONG_LENGTH);
+
+  admin_set_feature_mask(&capdu, &rapdu, 0);
+  assert_int_equal(device_config_is_pass_enabled(), 0);
+  assert_int_equal(device_config_is_openpgp_ccid_enabled(), 0);
+  assert_int_equal(device_config_is_openpgp_nfc_enabled(), 0);
+  assert_int_equal(device_config_is_piv_ccid_enabled(), 0);
+  assert_int_equal(device_config_is_piv_nfc_enabled(), 0);
+  assert_int_equal(device_config_is_webauthn_enabled(), 0);
+
   admin_send(&capdu, &rapdu, ADMIN_INS_CONFIG, 0x7F, 0x00, NULL, 0, 0);
   assert_int_equal(rapdu.sw, SW_WRONG_P1P2);
 
@@ -1777,6 +1799,7 @@ static void test_admin_platform_config_and_serial_apdus(void **state) {
   assert_int_equal(rapdu.data[0], 0);
   assert_int_equal(rapdu.data[3], 0);
   assert_int_equal(rapdu.data[4], 0);
+  assert_int_equal(rapdu.data[5], 0);
 
   uint8_t serial[4];
   device_config_fill_serial(serial);
@@ -1936,6 +1959,63 @@ static void test_admin_kbd_keymap_apdus(void **state) {
   assert_int_equal(rapdu.sw, SW_REFERENCE_DATA_NOT_FOUND);
 }
 
+static void test_runtime_feature_apdu_routing(void **state) {
+  (void)state;
+
+  static const uint8_t select_openpgp[] = {
+      0x00, 0xA4, 0x04, 0x00, 0x06, 0xD2, 0x76, 0x00, 0x01, 0x24, 0x01,
+  };
+  static const uint8_t select_piv[] = {
+      0x00, 0xA4, 0x04, 0x00, 0x05, 0xA0, 0x00, 0x00, 0x03, 0x08,
+  };
+  static const uint8_t fido_version[] = {
+      0x00, 0x03, 0x00, 0x00, 0x00,
+  };
+
+  uint8_t c_buf[64], r_buf[64];
+  CAPDU capdu = {.data = c_buf};
+  RAPDU rapdu = {.data = r_buf};
+
+  init_apdu_buffer();
+  device_init();
+  assert_int_equal(applets_install(), 0);
+  assert_int_equal(admin_install(1), 0);
+  admin_verify_default_pin(&capdu, &rapdu);
+
+  admin_set_feature_mask(&capdu, &rapdu, ADMIN_FEATURE_MASK & (uint8_t)~ADMIN_FEATURE_OPENPGP_CCID);
+  assert_int_equal(build_capdu(&capdu, select_openpgp, sizeof(select_openpgp)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_CCID);
+  assert_int_equal(rapdu.sw, SW_FILE_NOT_FOUND);
+
+  admin_set_feature_mask(&capdu, &rapdu, ADMIN_FEATURE_MASK);
+  assert_int_equal(build_capdu(&capdu, select_openpgp, sizeof(select_openpgp)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_CCID);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  init_apdu_buffer();
+  admin_verify_default_pin(&capdu, &rapdu);
+
+  admin_set_feature_mask(&capdu, &rapdu, ADMIN_FEATURE_MASK & (uint8_t)~ADMIN_FEATURE_OPENPGP_NFC);
+  assert_int_equal(build_capdu(&capdu, select_openpgp, sizeof(select_openpgp)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_NFC);
+  assert_int_equal(rapdu.sw, SW_FILE_NOT_FOUND);
+
+  admin_set_feature_mask(&capdu, &rapdu, ADMIN_FEATURE_MASK & (uint8_t)~ADMIN_FEATURE_PIV_CCID);
+  assert_int_equal(build_capdu(&capdu, select_piv, sizeof(select_piv)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_CCID);
+  assert_int_equal(rapdu.sw, SW_FILE_NOT_FOUND);
+
+  admin_set_feature_mask(&capdu, &rapdu, ADMIN_FEATURE_MASK & (uint8_t)~ADMIN_FEATURE_PIV_NFC);
+  assert_int_equal(build_capdu(&capdu, select_piv, sizeof(select_piv)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_NFC);
+  assert_int_equal(rapdu.sw, SW_FILE_NOT_FOUND);
+
+  admin_set_feature_mask(&capdu, &rapdu, ADMIN_FEATURE_MASK & (uint8_t)~ADMIN_FEATURE_WEBAUTHN);
+  init_apdu_buffer();
+  assert_int_equal(build_capdu(&capdu, fido_version, sizeof(fido_version)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_CCID);
+  assert_int_equal(rapdu.sw, SW_FILE_NOT_FOUND);
+}
+
 int main() {
   struct lfs_config cfg;
   lfs_filebd_t bd;
@@ -2002,6 +2082,7 @@ int main() {
       cmocka_unit_test(test_admin_read_core_commit_apdu),
       cmocka_unit_test(test_admin_flash_usage_apdus),
       cmocka_unit_test(test_admin_kbd_keymap_apdus),
+      cmocka_unit_test(test_runtime_feature_apdu_routing),
   };
 
   int ret = cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/test_core_helpers.c
+++ b/test/test_core_helpers.c
@@ -191,6 +191,18 @@ int platform_config_page_write(const void *page, size_t len) {
 
 uint8_t device_config_is_led_normally_on(void) { return led_normally_on ? 1 : 0; }
 
+uint8_t device_config_is_pass_enabled(void) { return 1; }
+
+uint8_t device_config_is_openpgp_ccid_enabled(void) { return 1; }
+
+uint8_t device_config_is_openpgp_nfc_enabled(void) { return 1; }
+
+uint8_t device_config_is_piv_ccid_enabled(void) { return 1; }
+
+uint8_t device_config_is_piv_nfc_enabled(void) { return 1; }
+
+uint8_t device_config_is_webauthn_enabled(void) { return 1; }
+
 static void test_tlv_get_length_safe_variants(void **state) {
   (void)state;
 


### PR DESCRIPTION
## Summary

- Add runtime feature switches for PASS, OpenPGP over CCID/NFC, PIV over CCID/NFC, and WebAuthn.
- Encode feature state in `ADMIN_INS_READ_CONFIG` byte `RDATA[5]` and update `ADMIN_INS_CONFIG` with `P1=ADMIN_P1_CFG_FEATURE` to write the full feature bitmask via `P2`.
- Route APDU processing with explicit transport context so OpenPGP/PIV policy can differ between CCID/WebUSB and NFC.
- Make the PASS switch control whether the USB keyboard HID interface is enumerated and serviced.
- Reject WebAuthn through FIDO APDU routing and CTAPHID MSG/CBOR dispatch when disabled.

## Validation

- `cmake --build build-codex-feature-switches -j4`
- `ctest --test-dir build-codex-feature-switches --output-on-failure`
- `git diff --check`
