### PR TITLE
Preserve RAPDU buffer after disabled applet

### DIFF
--- a/src/apdu.c
+++ b/src/apdu.c
@@ -67,6 +67,7 @@ static uint8_t fido_capdu_pke_owner;
 static uint8_t response_tail[APDU_COMMAND_OVERHEAD];
 static uint16_t response_tail_offset;
 static uint16_t response_tail_len;
+uint8_t *shared_io_buffer;
 #if !ENABLE_IFACE_CCID
 static uint8_t apdu_fallback_buffer[APDU_COMMAND_BUFFER_SIZE];
 #endif
@@ -120,10 +121,15 @@ static uint8_t applet_enabled_on_transport(enum APPLET applet, apdu_transport_t 
   }
 }
 
+static void rapdu_chaining_reset(void) {
+  memset(&rapdu_chaining, 0, sizeof(rapdu_chaining));
+  rapdu_chaining.rapdu.data = shared_io_buffer;
+}
+
 static void disabled_applet_response(RAPDU *rapdu) {
   current_applet = APPLET_NULL;
   apdu_response_source_clear();
-  memset(&rapdu_chaining, 0, sizeof(rapdu_chaining));
+  rapdu_chaining_reset();
   fido_capdu_reset();
   LL = 0;
   SW = SW_FILE_NOT_FOUND;
@@ -132,8 +138,6 @@ static void disabled_applet_response(RAPDU *rapdu) {
 static APDU_RESPONSE_SOURCE response_source;
 
 #define APDU_RESPONSE_CHUNK_SIZE 250
-
-uint8_t *shared_io_buffer;
 
 #if ENABLE_IFACE_CCID
 extern void ccid_init_apdu_buffer(void);
@@ -144,7 +148,6 @@ void init_apdu_buffer(void) {
   shared_io_buffer = apdu_fallback_buffer;
 #endif
   apdu_response_source_clear();
-  memset(&rapdu_chaining, 0, sizeof(rapdu_chaining));
   if (!fido_capdu_chaining.in_chaining) {
     memset(&fido_capdu_chaining, 0, sizeof(fido_capdu_chaining));
     fido_capdu_uses_pke = 0;
@@ -154,7 +157,7 @@ void init_apdu_buffer(void) {
 #if ENABLE_IFACE_CCID
   ccid_init_apdu_buffer();
 #endif
-  rapdu_chaining.rapdu.data = shared_io_buffer;
+  rapdu_chaining_reset();
   if (!fido_capdu_uses_pke) fido_capdu_chaining.capdu.data = shared_io_buffer;
 }
 

--- a/test/test_apdu.c
+++ b/test/test_apdu.c
@@ -1971,6 +1971,9 @@ static void test_runtime_feature_apdu_routing(void **state) {
   static const uint8_t fido_version[] = {
       0x00, 0x03, 0x00, 0x00, 0x00,
   };
+  static const uint8_t openpgp_get_aid[] = {
+      0x00, 0xCA, 0x00, 0x4F, 0x00,
+  };
 
   uint8_t c_buf[64], r_buf[64];
   CAPDU capdu = {.data = c_buf};
@@ -1991,6 +1994,13 @@ static void test_runtime_feature_apdu_routing(void **state) {
   assert_int_equal(build_capdu(&capdu, select_openpgp, sizeof(select_openpgp)), 0);
   process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_CCID);
   assert_int_equal(rapdu.sw, SW_NO_ERROR);
+
+  assert_int_equal(build_capdu(&capdu, openpgp_get_aid, sizeof(openpgp_get_aid)), 0);
+  process_apdu_from(&capdu, &rapdu, APDU_TRANSPORT_CCID);
+  assert_int_equal(rapdu.sw, SW_NO_ERROR);
+  assert_true(rapdu.len > 0);
+  assert_int_equal(rapdu.data[0], 0xD2);
+
   init_apdu_buffer();
   admin_verify_default_pin(&capdu, &rapdu);
 


### PR DESCRIPTION
## Summary
- reset RAPDU chaining through a helper that preserves the shared response buffer pointer
- cover disabled applet routing followed by an OpenPGP response-writing APDU

## Tests
- cmake --build build-codex-feature-switches -j4
- ctest --test-dir build-codex-feature-switches --output-on-failure
- git diff --check